### PR TITLE
Fixes assigned incidents dropdown showing for admins

### DIFF
--- a/resources/js/Layouts/Partials/NavigationItems.tsx
+++ b/resources/js/Layouts/Partials/NavigationItems.tsx
@@ -37,7 +37,7 @@ const navigationItems: NavigationItemInterface[] = [
             {
                 name: 'Assigned',
                 route: 'incidents.assigned',
-                roles: ['super-admin', 'admin', 'supervisor'],
+                roles: ['supervisor'],
             },
         ],
     },


### PR DESCRIPTION
# Bug Fix [CLOSES #48]

## Summary

Assigned incidents button would show for admins

## Root Cause Analysis

admin was listed in the roles for assigned incidents:

![image](https://github.com/user-attachments/assets/7f3a283a-d805-4810-a294-8f65d6826caa)


## Changes

Removed 'admin' from roles for assigned incidents

## Impact

NA

## Testing Strategy

1. Log in as Admin
2. See there is no option for assigned incidents

## Regression Risk

NA

## Checklist

- [x] The fix has been locally tested

- [x] New unit tests have been added to prevent future regressions

- [x] The documentation has been updated if necessary

## Additional Notes

NA