### PR TITLE
Witness Section Show Page

### DIFF
--- a/resources/js/Pages/Incident/Partials/InformationComponents/WitnessInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/InformationComponents/WitnessInformation.tsx
@@ -1,15 +1,32 @@
 import { Incident } from '@/types/incident/Incident';
 
-export default function WitnessInformation({
-    incident,
-}: {
-    incident: Incident;
-}) {
-    // TODO Witness Information
+export default function WitnessInformation({ incident }: { incident: Incident }) {
     return (
         <div className="mt-6 border-t border-gray-900/5 pt-6 sm:pr-4">
             <dt className="font-semibold text-gray-900 text-xl">Witnesses</dt>
-            {/* This will remain empty for now */}
+            <dd className="mt-2 text-gray-500">
+                {incident.witnesses && incident.witnesses.length > 0 ? (
+                    <ul className="list-none text-gray-900">
+                        {incident.witnesses.map((witness, index) => (
+                            <li key={index} className="flex flex-col gap-y-0 mb-4">
+                                <div className="flex items-center gap-x-1">
+                                    <span className="font-semibold">Name:</span> {witness.name}
+                                </div>
+                                <div className="flex items-center gap-x-1">
+                                    <span className="font-semibold">Email:</span>
+                                    {witness.email ? witness.email : 'None provided'}
+                                </div>
+                                <div className="flex items-center gap-x-1">
+                                    <span className="font-semibold">Phone:</span>
+                                    {witness.phone ? witness.phone : 'None provided'}
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p>No witnesses provided</p>
+                )}
+            </dd>
         </div>
     );
 }


### PR DESCRIPTION
# Feature Addition [CLOSES #55]

## Summary

Updates the show page to show all witnesses provided or state that none were provided.

## Rationale

This addition will allow users to now view all the relevant incident information within the show page.

## Design Documentation

N/A

## Changes

Each witness will display with the fields Name, Email, and Phone. With "None provided" for the Email and Phone if there was none given, and "No witnesses provided" if there were no witnesses mentioned in the incident.

## Impact

N/A

## Testing

N/A

## Screenshots/Video

![image](https://github.com/user-attachments/assets/8584366a-ab67-41e1-9fd0-f1d1d68f1122)

## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

N/A
