### PR TITLE
Fixes In Review status filter and filters/sort UI not being persisted…

### DIFF
--- a/app/Http/Controllers/Incident/AssignedIncidentsController.php
+++ b/app/Http/Controllers/Incident/AssignedIncidentsController.php
@@ -31,6 +31,9 @@ class AssignedIncidentsController extends Controller
         return Inertia::render('Incident/Index', [
             'incidents' => $assignedIncidents,
             'indexType' => 'assigned',
+            'currentFilters' => $filters,
+            'currentSortBy' => $sortBy,
+            'currentSortDirection' => $sortDirection,
         ]);
     }
 }

--- a/app/Http/Controllers/Incident/IncidentController.php
+++ b/app/Http/Controllers/Incident/IncidentController.php
@@ -34,6 +34,9 @@ class IncidentController extends Controller
         return Inertia::render('Incident/Index', [
             'incidents' => $incidents,
             'indexType' => 'all',
+            'currentFilters' => $filters,
+            'currentSortBy' => $sortBy,
+            'currentSortDirection' => $sortDirection,
         ]);
     }
 

--- a/app/Http/Controllers/Incident/OwnedIncidentsController.php
+++ b/app/Http/Controllers/Incident/OwnedIncidentsController.php
@@ -30,6 +30,9 @@ class OwnedIncidentsController extends Controller
         return Inertia::render('Incident/Index', [
             'incidents' => $ownedIncidents,
             'indexType' => 'owned',
+            'currentFilters' => $filters,
+            'currentSortBy' => $sortBy,
+            'currentSortDirection' => $sortDirection,
         ]);
     }
 }

--- a/resources/js/Pages/Incident/Index.tsx
+++ b/resources/js/Pages/Incident/Index.tsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, Link, router, usePage } from '@inertiajs/react';
+import { Head, Link, router } from '@inertiajs/react';
 import {
     ChevronDownIcon,
     ChevronUpIcon,
@@ -16,8 +16,6 @@ import { useEffect, useRef, useState } from 'react';
 import classNames from '@/Filters/classNames';
 import { descriptors } from '@/Pages/Incident/Stages/IncidentDropDownValues';
 import { IncidentStatus } from '@/Enums/IncidentStatus';
-import dateFormat from '@/Filters/dateFormat';
-import _ from 'underscore';
 
 type IndexType = 'owned' | 'assigned' | 'all';
 

--- a/resources/js/Pages/Incident/Partials/IndexComponents/IndexFilter.tsx
+++ b/resources/js/Pages/Incident/Partials/IndexComponents/IndexFilter.tsx
@@ -166,6 +166,7 @@ export default function IndexFilter({ filters, setFilters, resetFilters }: Index
                                                             ) && (
                                                                 <LabeledCheckbox
                                                                     key={innerIndex + value}
+                                                                    checked={checked}
                                                                     label={label}
                                                                     onChange={(e) =>
                                                                         handleSelectFilter(

--- a/tests/Feature/Incident/IndexTest.php
+++ b/tests/Feature/Incident/IndexTest.php
@@ -34,7 +34,8 @@ class IndexTest extends TestCase
 
         $response->assertOk();
 
-        $response->assertInertia(fn(AssertableInertia $page) => $page->component('Incident/Index')
+        $response->assertInertia(
+            fn (AssertableInertia $page) => $page->component('Incident/Index')
             ->has('currentSortBy')
             ->where('currentSortBy', 'descriptor')
             ->has('currentSortDirection')

--- a/tests/Feature/Incident/IndexTest.php
+++ b/tests/Feature/Incident/IndexTest.php
@@ -9,6 +9,42 @@ use Tests\TestCase;
 
 class IndexTest extends TestCase
 {
+    public function test_incident_index_passes_current_filters_and_sort_props()
+    {
+        $email = 'a@b.com';
+        $user = User::factory()->create(['email' => $email])->assignRole('user');
+        $this->actingAs($user);
+
+        Incident::factory()->create(['descriptor' => 'a', 'reporters_email' => $email]);
+        Incident::factory()->create(['descriptor' => 'b', 'reporters_email' => $email]);
+
+        $this->assertDatabaseCount('incidents', 2);
+
+        $response = $this->get(route(
+            'incidents.owned',
+            ['filters' => urlencode(json_encode(
+                [
+                    ['column' => 'descriptor', 'value' => 'a', 'comparator' => '=']
+                ]
+            )),
+                'sort_by' => 'descriptor',
+                'sort_direction' => 'asc'
+            ]
+        ));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn(AssertableInertia $page) => $page->component('Incident/Index')
+            ->has('currentSortBy')
+            ->where('currentSortBy', 'descriptor')
+            ->has('currentSortDirection')
+            ->where('currentSortDirection', 'asc')
+            ->has('currentFilters', 1)
+            ->where('currentFilters.0.column', 'descriptor')
+            ->where('currentFilters.0.value', 'a')
+            ->where('currentFilters.0.comparator', '=')
+        );
+    }
     public function test_owned_route_filters_incidents()
     {
         $email = 'a@b.com';


### PR DESCRIPTION
# Bug Fix [CLOSES #155] [CLOSES #156]

## Summary

- Fixes In Review status not being filtered
- Fixes filter and sort UI not persisting on reload

## Issue Link

#155 #156

## Root Cause Analysis

#155 - Using the Enum key, not value which is what is stored in the database. In Review enum has a hypen in the key, but no hyphen in the value.

#156 - Current filters weren't being reapplied on reload.

## Changes

- Status filters use the Status enum values instead of keys
- Incident index controllers pass the filter/sort values back to the frontend as props to be set on initial render

## Impact

NA

## Testing Strategy

Updated Index feature test

## Regression Risk
NA

## Checklist

- [ ] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes

Any further information needed to understand the fix or its impact.