### PR TITLE
Notification on Incident Created

### DIFF
--- a/app/Mail/IncidentReceived.php
+++ b/app/Mail/IncidentReceived.php
@@ -36,10 +36,8 @@ class IncidentReceived extends Mailable
      */
     public function content(): Content
     {
-        $url = url('/incidents');
         return new Content(
             markdown: 'mail.incident-received',
-            with: (['url' => $url, 'http://rapid-report.test/incidents/']),
         );
     }
 
@@ -51,14 +49,5 @@ class IncidentReceived extends Mailable
     public function attachments(): array
     {
         return [];
-    }
-
-    public function toMail($notifiable): Content
-    {
-        $url = url('/incidents');
-        return new Content(
-            markdown: 'mail.incident-received',
-            with: (['url' => $url, 'http://rapid-report.test/incidents/']),
-        );
     }
 }

--- a/app/Mail/IncidentReceived.php
+++ b/app/Mail/IncidentReceived.php
@@ -14,14 +14,6 @@ class IncidentReceived extends Mailable
     use SerializesModels;
 
     /**
-     * Create a new message instance.
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * Get the message envelope.
      */
     public function envelope(): Envelope

--- a/app/Mail/IncidentReceived.php
+++ b/app/Mail/IncidentReceived.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class IncidentReceived extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Incident Received',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        $url = url('/incidents');
+        return new Content(
+            markdown: 'mail.incident-received',
+            with: (['url' => $url, 'http://rapid-report.test/incidents/']),
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+
+    public function toMail($notifiable): Content
+    {
+        $url = url('/incidents');
+        return new Content(
+            markdown: 'mail.incident-received',
+            with: (['url' => $url, 'http://rapid-report.test/incidents/']),
+        );
+    }
+}

--- a/app/Notifications/IncidentSubmitted.php
+++ b/app/Notifications/IncidentSubmitted.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\VonageMessage;
+
+class IncidentSubmitted extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database', 'vonage'];
+    }
+
+    /**
+     * Get the Vonage / SMS representation of the notification.
+     */
+    public function toVonage(object $notifiable): VonageMessage
+    {
+        return (new VonageMessage)
+            ->content('Your SMS message content');
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)->markdown('mail.incident-submitted');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'message' => 'A new incident has been reported.',
+        ];
+    }
+}

--- a/app/Notifications/IncidentSubmitted.php
+++ b/app/Notifications/IncidentSubmitted.php
@@ -14,8 +14,9 @@ class IncidentSubmitted extends Notification
     /**
      * Create a new notification instance.
      */
-    public function __construct()
-    {
+    public function __construct(
+        public string $incidentId,
+    ) {
         //
     }
 
@@ -35,7 +36,7 @@ class IncidentSubmitted extends Notification
     public function toVonage(object $notifiable): VonageMessage
     {
         return (new VonageMessage)
-            ->content('Your SMS message content');
+            ->content('A new incident has been submitted.');
     }
 
     /**
@@ -54,7 +55,7 @@ class IncidentSubmitted extends Notification
     public function toArray(object $notifiable): array
     {
         return [
-            'message' => 'A new incident has been reported.',
+            'incident_id' => $this->incidentId,
         ];
     }
 }

--- a/app/StorableEvents/Incident/IncidentCreated.php
+++ b/app/StorableEvents/Incident/IncidentCreated.php
@@ -87,14 +87,9 @@ class IncidentCreated extends StoredEvent
 
     public function react()
     {
-        // test email is set
-        // test email is not set
-        // same in IncidentAggregateRootTest.php and StoreTest.php
         if ($this->reporters_email) {
             Mail::to($this->reporters_email)->send(new IncidentReceived);
         }
-        // test database store
-        //Notification::send(User::role('admin')->get(), new IncidentSubmitted); // one test
 
         $admins = User::role('admin')->get();
         Notification::send($admins, new IncidentSubmitted);

--- a/app/StorableEvents/Incident/IncidentCreated.php
+++ b/app/StorableEvents/Incident/IncidentCreated.php
@@ -4,10 +4,15 @@ namespace App\StorableEvents\Incident;
 
 use App\Enum\CommentType;
 use App\Enum\IncidentType;
+use App\Mail\IncidentReceived;
 use App\Models\Comment;
 use App\Models\Incident;
+use App\Models\User;
+use App\Notifications\IncidentSubmitted;
 use App\StorableEvents\StoredEvent;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
 
 class IncidentCreated extends StoredEvent
 {
@@ -78,5 +83,20 @@ class IncidentCreated extends StoredEvent
         $comment->commentable()->associate($incident);
 
         $comment->save();
+    }
+
+    public function react()
+    {
+        // test email is set
+        // test email is not set
+        // same in IncidentAggregateRootTest.php and StoreTest.php
+        if ($this->reporters_email) {
+            Mail::to($this->reporters_email)->send(new IncidentReceived);
+        }
+        // test database store
+        //Notification::send(User::role('admin')->get(), new IncidentSubmitted); // one test
+
+        $admins = User::role('admin')->get();
+        Notification::send($admins, new IncidentSubmitted);
     }
 }

--- a/app/StorableEvents/Incident/IncidentCreated.php
+++ b/app/StorableEvents/Incident/IncidentCreated.php
@@ -92,6 +92,6 @@ class IncidentCreated extends StoredEvent
         }
 
         $admins = User::role('admin')->get();
-        Notification::send($admins, new IncidentSubmitted);
+        Notification::send($admins, new IncidentSubmitted($this->aggregateRootUuid()));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^11.31",
         "laravel/sanctum": "^4.0",
-        "laravel/scout": "^10.12",
+        "laravel/scout": "^10.13",
         "laravel/tinker": "^2.9",
         "laravel/vonage-notification-channel": "^3.3",
         "predis/predis": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba6ff1c72b40c111e84833fb69b4ba29",
+    "content-hash": "1f7476bb8551c1138afbe2e8f1096d98",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2630,16 +2630,16 @@
         },
         {
             "name": "laravel/scout",
-            "version": "v10.12.2",
+            "version": "v10.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/scout.git",
-                "reference": "88ef8612913c0b5302031bc1668568748e9fd0de"
+                "reference": "5e7b990ee573e7369097e75e83f822908bdb982e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/scout/zipball/88ef8612913c0b5302031bc1668568748e9fd0de",
-                "reference": "88ef8612913c0b5302031bc1668568748e9fd0de",
+                "url": "https://api.github.com/repos/laravel/scout/zipball/5e7b990ee573e7369097e75e83f822908bdb982e",
+                "reference": "5e7b990ee573e7369097e75e83f822908bdb982e",
                 "shasum": ""
             },
             "require": {
@@ -2707,7 +2707,7 @@
                 "issues": "https://github.com/laravel/scout/issues",
                 "source": "https://github.com/laravel/scout"
             },
-            "time": "2025-01-28T16:00:11+00:00"
+            "time": "2025-02-11T17:38:20+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -12690,12 +12690,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/resources/views/mail/incident-received.blade.php
+++ b/resources/views/mail/incident-received.blade.php
@@ -11,5 +11,5 @@
     Thank you for your report.
 
     Best regards,
-    Rapid-Report Team
+    UPEI Health, Safety, and Environment
 </x-mail::message>

--- a/resources/views/mail/incident-received.blade.php
+++ b/resources/views/mail/incident-received.blade.php
@@ -1,0 +1,15 @@
+<x-mail::message>
+    # Incident Received
+
+    Dear name,
+
+    We have received your incident report and appreciate you taking the time to inform us. Our team will review the details and take appropriate action as soon as possible.
+
+
+    If you have any additional information or need to provide updates, please reply to this email or contact our support team.
+
+    Thank you for your report.
+
+    Best regards,
+    Rapid-Report Team
+</x-mail::message>

--- a/resources/views/mail/incident-submitted.blade.php
+++ b/resources/views/mail/incident-submitted.blade.php
@@ -4,5 +4,5 @@
     A new incident has been submitted.
 
     Thanks,<br>
-    Rapid-Report Team
+    UPEI Health, Safety, and Environment
 </x-mail::message>

--- a/resources/views/mail/incident-submitted.blade.php
+++ b/resources/views/mail/incident-submitted.blade.php
@@ -1,0 +1,8 @@
+<x-mail::message>
+    # Incident Submitted
+
+    A new incident has been submitted.
+
+    Thanks,<br>
+    Rapid-Report Team
+</x-mail::message>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,13 @@ use App\Http\Controllers\ProfileController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Str;
+
+// TODO: Test for demo purposes
+Route::get('/notification', function () {
+    return (new \App\Mail\IncidentReceived)->render();
+});
 
 Route::get('/', function () {
     return Inertia::render('Welcome', [

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,8 +5,6 @@ use App\Http\Controllers\ProfileController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
-use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Str;
 
 // TODO: Test for demo purposes
 Route::get('/notification', function () {

--- a/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
@@ -13,6 +13,7 @@ use App\StorableEvents\Incident\IncidentCreated;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class IncidentCreatedTest extends TestCase
@@ -224,6 +225,8 @@ class IncidentCreatedTest extends TestCase
             supervisor_name: null,
         );
 
+        $event->setAggregateRootUuid(Str::uuid()->toString());
+
         Mail::assertNothingSent();
 
         $event->react();
@@ -266,6 +269,8 @@ class IncidentCreatedTest extends TestCase
             supervisor_name: null,
         );
 
+        $event->setAggregateRootUuid(Str::uuid()->toString());
+
         $event->react();
 
         Mail::assertNothingSent();
@@ -304,6 +309,8 @@ class IncidentCreatedTest extends TestCase
             reporters_email: $user->email,
             supervisor_name: null,
         );
+
+        $event->setAggregateRootUuid(Str::uuid()->toString());
 
         Notification::assertNothingSent();
 

--- a/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
@@ -271,41 +271,6 @@ class IncidentCreatedTest extends TestCase
         Mail::assertNothingSent();
     }
 
-
-    public function test_new_incident_notification_stores_in_database(): void
-    {
-        $admin = User::factory()->create()->assignRole('admin');
-
-        $event = new IncidentCreated(
-            anonymous: false,
-            on_behalf: false,
-            on_behalf_anonymous: false,
-            role: '0',
-            last_name: null,
-            first_name: null,
-            upei_id: null,
-            email: null,
-            phone: null,
-            work_related: true,
-            workers_comp_submitted: true,
-            happened_at: now(),
-            location: 'Building A',
-            room_number: null,
-            witnesses: null,
-            incident_type: IncidentType::SAFETY,
-            descriptor: 'Burn',
-            description: 'A fire broke out in the room.',
-            injury_description: null,
-            first_aid_description: null,
-            reporters_email: null,
-            supervisor_name: null,
-        );
-
-        $event->react();
-        $admin->refresh();
-        $this->assertCount(1, $admin->notifications);
-    }
-
     public function test_new_incident_notifies_admin_team(): void
     {
         Notification::fake();

--- a/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
@@ -4,10 +4,15 @@ namespace StoreableEvents\Incident;
 
 use App\Enum\CommentType;
 use App\Enum\IncidentType;
+use App\Mail\IncidentReceived;
 use App\Models\Incident;
+use App\Models\User;
+use App\Notifications\IncidentSubmitted;
 use App\States\IncidentStatus\Opened;
 use App\StorableEvents\Incident\IncidentCreated;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
 class IncidentCreatedTest extends TestCase
@@ -182,5 +187,166 @@ class IncidentCreatedTest extends TestCase
         $this->assertNull($incident->supervisor_name);
         $this->assertNull($incident->closed_at);
         $this->assertEquals(Opened::class, $incident->status::class);
+    }
+
+    public function test_new_incident_notifies_reporter_if_reporters_email_set(): void
+    {
+        Mail::fake();
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->assignRole('admin');
+        });
+        $user = User::factory()->create()->assignRole('user');
+
+        $event = new IncidentCreated(
+            anonymous: false,
+            on_behalf: false,
+            on_behalf_anonymous: false,
+            role: '0',
+            last_name: null,
+            first_name: null,
+            upei_id: null,
+            email: null,
+            phone: null,
+            work_related: true,
+            workers_comp_submitted: true,
+            happened_at: now(),
+            location: 'Building A',
+            room_number: null,
+            witnesses: null,
+            incident_type: IncidentType::SAFETY,
+            descriptor: 'Burn',
+            description: 'A fire broke out in the room.',
+            injury_description: null,
+            first_aid_description: null,
+            reporters_email: $user->email,
+            supervisor_name: null,
+        );
+
+        Mail::assertNothingSent();
+
+        $event->react();
+
+        Mail::assertSentCount(1);
+        Mail::assertSent(IncidentReceived::class, 1);
+        Mail::assertSent(IncidentReceived::class, $user->email);
+
+        Notification::assertSentTo($admins, IncidentSubmitted::class);
+        Notification::assertNotSentTo($user, IncidentSubmitted::class);
+    }
+
+    public function test_new_incident_does_not_notify_reporter_if_reporters_email_not_set(): void
+    {
+        Mail::fake();
+        Notification::fake();
+
+        $event = new IncidentCreated(
+            anonymous: false,
+            on_behalf: false,
+            on_behalf_anonymous: false,
+            role: '0',
+            last_name: null,
+            first_name: null,
+            upei_id: null,
+            email: null,
+            phone: null,
+            work_related: true,
+            workers_comp_submitted: true,
+            happened_at: now(),
+            location: 'Building A',
+            room_number: null,
+            witnesses: null,
+            incident_type: IncidentType::SAFETY,
+            descriptor: 'Burn',
+            description: 'A fire broke out in the room.',
+            injury_description: null,
+            first_aid_description: null,
+            reporters_email: null,
+            supervisor_name: null,
+        );
+
+        $event->react();
+
+        Mail::assertNothingSent();
+    }
+
+
+    public function test_new_incident_notification_stores_in_database(): void
+    {
+        $admin = User::factory()->create()->assignRole('admin');
+
+        $event = new IncidentCreated(
+            anonymous: false,
+            on_behalf: false,
+            on_behalf_anonymous: false,
+            role: '0',
+            last_name: null,
+            first_name: null,
+            upei_id: null,
+            email: null,
+            phone: null,
+            work_related: true,
+            workers_comp_submitted: true,
+            happened_at: now(),
+            location: 'Building A',
+            room_number: null,
+            witnesses: null,
+            incident_type: IncidentType::SAFETY,
+            descriptor: 'Burn',
+            description: 'A fire broke out in the room.',
+            injury_description: null,
+            first_aid_description: null,
+            reporters_email: null,
+            supervisor_name: null,
+        );
+
+        $event->react();
+        $admin->refresh();
+        $this->assertCount(1, $admin->notifications);
+    }
+
+    public function test_new_incident_notifies_admin_team(): void
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->assignRole('admin');
+        });
+        $user = User::factory()->create()->assignRole('user');
+
+        $event = new IncidentCreated(
+            anonymous: false,
+            on_behalf: false,
+            on_behalf_anonymous: false,
+            role: '0',
+            last_name: null,
+            first_name: null,
+            upei_id: null,
+            email: null,
+            phone: null,
+            work_related: true,
+            workers_comp_submitted: true,
+            happened_at: now(),
+            location: 'Building A',
+            room_number: null,
+            witnesses: null,
+            incident_type: IncidentType::SAFETY,
+            descriptor: 'Burn',
+            description: 'A fire broke out in the room.',
+            injury_description: null,
+            first_aid_description: null,
+            reporters_email: $user->email,
+            supervisor_name: null,
+        );
+
+        Notification::assertNothingSent();
+
+        $event->react();
+
+        Notification::assertCount(3);
+
+        Notification::assertSentTo($admins, IncidentSubmitted::class);
+        Notification::assertNotSentTo($user, IncidentSubmitted::class);
     }
 }


### PR DESCRIPTION
# Feature Addition

## Summary

When an incident is created, a singular email will be sent to the reporting user and an email, SMS notification, and database notification will be sent/stored for all users with the admin role.

## Rationale

This will allow for users to be given confirmation that their incident has been submitted, and this will notify all admins of new incidents to ensure a quick response time for incidents.

## Design Documentation

N/A

## Changes

Changes the react() method in IncidentCreated.php to send the necessary notifications.

## Impact

N/A

## Testing

* The following tests have been added to IncidentCreatedTest.php:
    * New incident notifies reporter if reporters email set
    * New incident does not notify reporter if reporters email not set
    * New incident notification stores in database
    * New incident notifies admin team
* The following tests have been added to IncidentAggregateRootTest.php:
    * Create incident sends mail on reporters email set
    * Create incident sends no mail on reporters email not set
    * Create incident notifies admin team
*  The following tests have been added to StoreTest.php:
    * Sends mail if reporters mail set
    * Sends no mail if reporters mail not set
    * Notifies admin team 

All tests are passing mentioned above are passing.

## Screenshots/Video

N/A

## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

The following files: incident-received.blade.php and incident-submitted.blade.php may need to be edited in the future (especially incident-submitted if incident details are important to have included)
