### PR TITLE
171 apply sort on incident index column click

### DIFF
--- a/resources/js/Components/DangerButton.tsx
+++ b/resources/js/Components/DangerButton.tsx
@@ -10,9 +10,9 @@ export default function DangerButton({
         <button
             {...props}
             className={classNames(
-                'rounded-md bg-upei-red-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm',
-                'hover:bg-upei-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-upei-red-600',
-                'disabled:opacity-25 disabled:hover:bg-upei-red-600',
+                'rounded-md bg-upei-red-500 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm',
+                'hover:bg-upei-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-upei-red-500',
+                'disabled:opacity-25 disabled:hover:bg-upei-red-500',
                 className
             )}
         >

--- a/resources/js/Pages/Incident/Index.tsx
+++ b/resources/js/Pages/Incident/Index.tsx
@@ -18,7 +18,7 @@ import { descriptors } from '@/Pages/Incident/Stages/IncidentDropDownValues';
 import { IncidentStatus } from '@/Enums/IncidentStatus';
 import Badge from '@/Components/Badge';
 import { incidentBadgeColor } from '@/Filters/incidentBadgeColor';
-import Pagination from "@/Components/Pagination";
+import Pagination from '@/Components/Pagination';
 
 type IndexType = 'owned' | 'assigned' | 'all';
 
@@ -242,16 +242,16 @@ export default function Index({
                                                 scope="col"
                                                 className="hidden px-6 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell"
                                             >
-                                                <div className="flex items-center">
+                                                <div
+                                                    onClick={() => handleSort('created_at')}
+                                                    className="flex items-center hover:cursor-pointer select-none"
+                                                >
                                                     Submitted On
-                                                    <div
-                                                        className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible"
-                                                        onClick={() => handleSort('created_at')}
-                                                    >
+                                                    <div className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon
                                                             aria-hidden="true"
                                                             className={classNames(
-                                                                'size-5 hover:cursor-pointer pt-1',
+                                                                'size-5 pt-1',
                                                                 sortDirection === 'asc' &&
                                                                     sortedBy === 'created_at'
                                                                     ? 'text-gray-900'
@@ -261,7 +261,7 @@ export default function Index({
                                                         <ChevronDownIcon
                                                             aria-hidden="true"
                                                             className={classNames(
-                                                                'size-5 hover:cursor-pointer pb-1',
+                                                                'size-5 pb-1',
                                                                 sortDirection === 'desc' &&
                                                                     sortedBy === 'created_at'
                                                                     ? 'text-gray-900'
@@ -275,7 +275,10 @@ export default function Index({
                                                 scope="col"
                                                 className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
                                             >
-                                                <div className="flex items-center">
+                                                <div
+                                                    onClick={() => handleSort('name')}
+                                                    className="flex items-center hover:cursor-pointer select-none"
+                                                >
                                                     <div>
                                                         <span className="sm:block md:hidden">
                                                             Incident
@@ -284,14 +287,11 @@ export default function Index({
                                                             Reporter
                                                         </span>
                                                     </div>
-                                                    <div
-                                                        className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible"
-                                                        onClick={() => handleSort('name')}
-                                                    >
+                                                    <div className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon
                                                             aria-hidden="true"
                                                             className={classNames(
-                                                                'size-5 hover:cursor-pointer pt-1',
+                                                                'size-5 pt-1',
                                                                 sortDirection === 'asc' &&
                                                                     sortedBy === 'name'
                                                                     ? 'text-gray-900'
@@ -301,7 +301,7 @@ export default function Index({
                                                         <ChevronDownIcon
                                                             aria-hidden="true"
                                                             className={classNames(
-                                                                'size-5 hover:cursor-pointer pb-1',
+                                                                'size-5 pb-1',
                                                                 sortDirection === 'desc' &&
                                                                     sortedBy === 'name'
                                                                     ? 'text-gray-900'
@@ -315,16 +315,16 @@ export default function Index({
                                                 scope="col"
                                                 className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell"
                                             >
-                                                <div className="flex items-center">
+                                                <div
+                                                    onClick={() => handleSort('descriptor')}
+                                                    className="flex items-center hover:cursor-pointer select-none"
+                                                >
                                                     Descriptor
-                                                    <div
-                                                        className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible"
-                                                        onClick={() => handleSort('descriptor')}
-                                                    >
+                                                    <div className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon
                                                             aria-hidden="true"
                                                             className={classNames(
-                                                                'size-5 hover:cursor-pointer pt-1',
+                                                                'size-5 pt-1',
                                                                 sortDirection === 'asc' &&
                                                                     sortedBy === 'descriptor'
                                                                     ? 'text-gray-900'
@@ -334,7 +334,7 @@ export default function Index({
                                                         <ChevronDownIcon
                                                             aria-hidden="true"
                                                             className={classNames(
-                                                                'size-5 hover:cursor-pointer pb-1',
+                                                                'size-5 pb-1',
                                                                 sortDirection === 'desc' &&
                                                                     sortedBy === 'descriptor'
                                                                     ? 'text-gray-900'
@@ -348,16 +348,16 @@ export default function Index({
                                                 scope="col"
                                                 className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell"
                                             >
-                                                <div className="flex items-center">
+                                                <div
+                                                    onClick={() => handleSort('location')}
+                                                    className="flex items-center hover:cursor-pointer select-none"
+                                                >
                                                     Location
-                                                    <div
-                                                        className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible"
-                                                        onClick={() => handleSort('location')}
-                                                    >
+                                                    <div className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon
                                                             aria-hidden="true"
                                                             className={classNames(
-                                                                'size-5 hover:cursor-pointer pt-1',
+                                                                'size-5 pt-1',
                                                                 sortDirection === 'asc' &&
                                                                     sortedBy === 'location'
                                                                     ? 'text-gray-900'
@@ -367,7 +367,7 @@ export default function Index({
                                                         <ChevronDownIcon
                                                             aria-hidden="true"
                                                             className={classNames(
-                                                                'size-5 hover:cursor-pointer pb-1',
+                                                                'size-5 pb-1',
                                                                 sortDirection === 'desc' &&
                                                                     sortedBy === 'location'
                                                                     ? 'text-gray-900'
@@ -382,16 +382,16 @@ export default function Index({
                                                 scope="col"
                                                 className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell"
                                             >
-                                                <div className="flex items-center">
+                                                <div
+                                                    onClick={() => handleSort('status')}
+                                                    className="flex items-center hover:cursor-pointer select-none"
+                                                >
                                                     Status
-                                                    <div
-                                                        className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible"
-                                                        onClick={() => handleSort('status')}
-                                                    >
+                                                    <div className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon
                                                             aria-hidden="true"
                                                             className={classNames(
-                                                                'size-5 hover:cursor-pointer pt-1',
+                                                                'size-5 pt-1',
                                                                 sortDirection === 'asc' &&
                                                                     sortedBy === 'status'
                                                                     ? 'text-gray-900'
@@ -401,7 +401,7 @@ export default function Index({
                                                         <ChevronDownIcon
                                                             aria-hidden="true"
                                                             className={classNames(
-                                                                'size-5 hover:cursor-pointer pb-1',
+                                                                'size-5 pb-1',
                                                                 sortDirection === 'desc' &&
                                                                     sortedBy === 'status'
                                                                     ? 'text-gray-900'

--- a/resources/js/Pages/Incident/Index.tsx
+++ b/resources/js/Pages/Incident/Index.tsx
@@ -12,13 +12,14 @@ import { PencilIcon } from '@heroicons/react/24/outline';
 import { uppercaseWordFormat } from '@/Filters/uppercaseWordFormat';
 import { nameFilter } from '@/Filters/nameFilter';
 import IndexFilter from '@/Pages/Incident/Partials/IndexComponents/IndexFilter';
-import { useEffect, useRef, useState } from 'react';
+import { MouseEventHandler, useEffect, useRef, useState } from 'react';
 import classNames from '@/Filters/classNames';
 import { descriptors } from '@/Pages/Incident/Stages/IncidentDropDownValues';
 import { IncidentStatus } from '@/Enums/IncidentStatus';
 import Badge from '@/Components/Badge';
 import { incidentBadgeColor } from '@/Filters/incidentBadgeColor';
 import Pagination from '@/Components/Pagination';
+import { sortBy } from 'underscore';
 
 type IndexType = 'owned' | 'assigned' | 'all';
 
@@ -140,20 +141,28 @@ export default function Index({
 
     const [sortedBy, setSortedBy] = useState<SortBy>(currentSortBy ?? 'created_at');
 
-    const [sortDirection, setSortDirection] = useState<SortDirection>(
+    const [sortedDirection, setSortedDirection] = useState<SortDirection>(
         currentSortDirection ?? 'desc'
     );
 
     const resetFilters = () => setFilters(initialFilters);
 
-    const handleSort = (sortBy: SortBy) => {
-        if (sortBy !== sortedBy || sortDirection === 'asc') {
-            setSortDirection('desc');
+    const handleSortCycle = (sortBy: SortBy) => {
+        if (sortBy !== sortedBy || sortedDirection === 'asc') {
+            setSortedDirection('desc');
         } else {
-            setSortDirection('asc');
+            setSortedDirection('asc');
         }
 
         setSortedBy(sortBy);
+    };
+
+    const handleSort = (e: MouseEvent, sortBy: SortBy, sortDirection: SortDirection) => {
+        e.stopPropagation();
+        if (sortBy === sortedBy && sortDirection === sortedDirection) return;
+
+        setSortedBy(sortBy);
+        setSortedDirection(sortDirection);
     };
 
     useEffect(() => {
@@ -163,7 +172,7 @@ export default function Index({
         } else {
             hasMounted.current = true;
         }
-    }, [filters, sortDirection, sortedBy]);
+    }, [filters, sortedDirection, sortedBy]);
 
     const handleSortAndFilter = () => {
         const processedFilters = Object.entries(filters).reduce<ProcessedFilter[]>(
@@ -191,7 +200,7 @@ export default function Index({
             {
                 filters: encodeURIComponent(JSON.stringify(processedFilters)),
                 sort_by: sortedBy,
-                sort_direction: sortDirection,
+                sort_direction: sortedDirection,
             },
             {
                 preserveState: true,
@@ -243,16 +252,23 @@ export default function Index({
                                                 className="hidden px-6 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell"
                                             >
                                                 <div
-                                                    onClick={() => handleSort('created_at')}
+                                                    onClick={() => handleSortCycle('created_at')}
                                                     className="flex items-center hover:cursor-pointer select-none"
                                                 >
                                                     Submitted On
                                                     <div className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon
                                                             aria-hidden="true"
+                                                            onClick={(e) =>
+                                                                handleSort(
+                                                                    e as unknown as MouseEvent,
+                                                                    'created_at',
+                                                                    'asc'
+                                                                )
+                                                            }
                                                             className={classNames(
                                                                 'size-5 pt-1',
-                                                                sortDirection === 'asc' &&
+                                                                sortedDirection === 'asc' &&
                                                                     sortedBy === 'created_at'
                                                                     ? 'text-gray-900'
                                                                     : 'text-gray-400'
@@ -260,9 +276,16 @@ export default function Index({
                                                         />
                                                         <ChevronDownIcon
                                                             aria-hidden="true"
+                                                            onClick={(e) =>
+                                                                handleSort(
+                                                                    e as unknown as MouseEvent,
+                                                                    'created_at',
+                                                                    'desc'
+                                                                )
+                                                            }
                                                             className={classNames(
                                                                 'size-5 pb-1',
-                                                                sortDirection === 'desc' &&
+                                                                sortedDirection === 'desc' &&
                                                                     sortedBy === 'created_at'
                                                                     ? 'text-gray-900'
                                                                     : 'text-gray-400'
@@ -276,7 +299,7 @@ export default function Index({
                                                 className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
                                             >
                                                 <div
-                                                    onClick={() => handleSort('name')}
+                                                    onClick={() => handleSortCycle('name')}
                                                     className="flex items-center hover:cursor-pointer select-none"
                                                 >
                                                     <div>
@@ -290,9 +313,16 @@ export default function Index({
                                                     <div className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon
                                                             aria-hidden="true"
+                                                            onClick={(e) =>
+                                                                handleSort(
+                                                                    e as unknown as MouseEvent,
+                                                                    'name',
+                                                                    'asc'
+                                                                )
+                                                            }
                                                             className={classNames(
                                                                 'size-5 pt-1',
-                                                                sortDirection === 'asc' &&
+                                                                sortedDirection === 'asc' &&
                                                                     sortedBy === 'name'
                                                                     ? 'text-gray-900'
                                                                     : 'text-gray-400'
@@ -300,9 +330,16 @@ export default function Index({
                                                         />
                                                         <ChevronDownIcon
                                                             aria-hidden="true"
+                                                            onClick={(e) =>
+                                                                handleSort(
+                                                                    e as unknown as MouseEvent,
+                                                                    'name',
+                                                                    'desc'
+                                                                )
+                                                            }
                                                             className={classNames(
                                                                 'size-5 pb-1',
-                                                                sortDirection === 'desc' &&
+                                                                sortedDirection === 'desc' &&
                                                                     sortedBy === 'name'
                                                                     ? 'text-gray-900'
                                                                     : 'text-gray-400'
@@ -316,16 +353,23 @@ export default function Index({
                                                 className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell"
                                             >
                                                 <div
-                                                    onClick={() => handleSort('descriptor')}
+                                                    onClick={() => handleSortCycle('descriptor')}
                                                     className="flex items-center hover:cursor-pointer select-none"
                                                 >
                                                     Descriptor
                                                     <div className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon
                                                             aria-hidden="true"
+                                                            onClick={(e) =>
+                                                                handleSort(
+                                                                    e as unknown as MouseEvent,
+                                                                    'descriptor',
+                                                                    'asc'
+                                                                )
+                                                            }
                                                             className={classNames(
                                                                 'size-5 pt-1',
-                                                                sortDirection === 'asc' &&
+                                                                sortedDirection === 'asc' &&
                                                                     sortedBy === 'descriptor'
                                                                     ? 'text-gray-900'
                                                                     : 'text-gray-400'
@@ -333,9 +377,16 @@ export default function Index({
                                                         />
                                                         <ChevronDownIcon
                                                             aria-hidden="true"
+                                                            onClick={(e) =>
+                                                                handleSort(
+                                                                    e as unknown as MouseEvent,
+                                                                    'descriptor',
+                                                                    'desc'
+                                                                )
+                                                            }
                                                             className={classNames(
                                                                 'size-5 pb-1',
-                                                                sortDirection === 'desc' &&
+                                                                sortedDirection === 'desc' &&
                                                                     sortedBy === 'descriptor'
                                                                     ? 'text-gray-900'
                                                                     : 'text-gray-400'
@@ -349,16 +400,23 @@ export default function Index({
                                                 className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell"
                                             >
                                                 <div
-                                                    onClick={() => handleSort('location')}
+                                                    onClick={() => handleSortCycle('location')}
                                                     className="flex items-center hover:cursor-pointer select-none"
                                                 >
                                                     Location
                                                     <div className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon
                                                             aria-hidden="true"
+                                                            onClick={(e) =>
+                                                                handleSort(
+                                                                    e as unknown as MouseEvent,
+                                                                    'location',
+                                                                    'asc'
+                                                                )
+                                                            }
                                                             className={classNames(
                                                                 'size-5 pt-1',
-                                                                sortDirection === 'asc' &&
+                                                                sortedDirection === 'asc' &&
                                                                     sortedBy === 'location'
                                                                     ? 'text-gray-900'
                                                                     : 'text-gray-400'
@@ -366,9 +424,16 @@ export default function Index({
                                                         />
                                                         <ChevronDownIcon
                                                             aria-hidden="true"
+                                                            onClick={(e) =>
+                                                                handleSort(
+                                                                    e as unknown as MouseEvent,
+                                                                    'location',
+                                                                    'desc'
+                                                                )
+                                                            }
                                                             className={classNames(
                                                                 'size-5 pb-1',
-                                                                sortDirection === 'desc' &&
+                                                                sortedDirection === 'desc' &&
                                                                     sortedBy === 'location'
                                                                     ? 'text-gray-900'
                                                                     : 'text-gray-400'
@@ -383,16 +448,23 @@ export default function Index({
                                                 className="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 md:table-cell"
                                             >
                                                 <div
-                                                    onClick={() => handleSort('status')}
+                                                    onClick={() => handleSortCycle('status')}
                                                     className="flex items-center hover:cursor-pointer select-none"
                                                 >
                                                     Status
                                                     <div className="ml-2 rounded text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon
                                                             aria-hidden="true"
+                                                            onClick={(e) =>
+                                                                handleSort(
+                                                                    e as unknown as MouseEvent,
+                                                                    'status',
+                                                                    'asc'
+                                                                )
+                                                            }
                                                             className={classNames(
                                                                 'size-5 pt-1',
-                                                                sortDirection === 'asc' &&
+                                                                sortedDirection === 'asc' &&
                                                                     sortedBy === 'status'
                                                                     ? 'text-gray-900'
                                                                     : 'text-gray-400'
@@ -400,9 +472,16 @@ export default function Index({
                                                         />
                                                         <ChevronDownIcon
                                                             aria-hidden="true"
+                                                            onClick={(e) =>
+                                                                handleSort(
+                                                                    e as unknown as MouseEvent,
+                                                                    'status',
+                                                                    'desc'
+                                                                )
+                                                            }
                                                             className={classNames(
                                                                 'size-5 pb-1',
-                                                                sortDirection === 'desc' &&
+                                                                sortedDirection === 'desc' &&
                                                                     sortedBy === 'status'
                                                                     ? 'text-gray-900'
                                                                     : 'text-gray-400'


### PR DESCRIPTION
# Bug Fix

## Summary

Applies sort on incident index column click

## Issue Link

CLOSES #171 

## Root Cause Analysis

NA

## Changes

- Fixes clicking on incident index column name not sorting
- Updates DangerButton to be lighter by default and darker on hover

## Impact

NA

## Testing Strategy

Click on incident index column name

## Regression Risk

NA

## Checklist

- [x] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [x] The documentation has been updated if necessary

## Additional Notes
NA
Any further information needed to understand the fix or its impact.