### PR TITLE
Update role on user

### DIFF
--- a/app/Enum/RolesEnum.php
+++ b/app/Enum/RolesEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enum;
+
+enum RolesEnum: string
+{
+    case SUPER_ADMIN = 'super-admin';
+    case ADMIN = 'admin';
+    case SUPERVISOR = 'supervisor';
+    case USER = 'user';
+}

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -24,7 +24,9 @@ class UserController extends Controller
     {
         $this->authorize('delete', $user);
 
-        $event = new UserDeleted($user->id);
+        $event = new UserDeleted(
+            user_id: $user->id
+        );
 
         event($event);
 

--- a/app/Http/Controllers/User/UserRoleController.php
+++ b/app/Http/Controllers/User/UserRoleController.php
@@ -2,16 +2,35 @@
 
 namespace App\Http\Controllers\User;
 
+use App\Enum\RolesEnum;
 use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\StorableEvents\User\UserRoleUpdated;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class UserRoleController extends Controller
 {
     /**
-     * Handle the incoming request.
+     * Update the specified User Role in storage.
      */
-    public function __invoke(Request $request)
+    public function update(Request $request, User $user)
     {
-        //
+        $this->authorize('updateRole', $user);
+
+        $request->validate([
+            'role' => [Rule::enum(RolesEnum::class)],
+        ]);
+
+        $role = $request->enum('role', RolesEnum::class);
+
+        $event = new UserRoleUpdated(
+            user_id: $user->id,
+            role: $role,
+        );
+
+        event($event);
+
+        return back();
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -25,4 +25,13 @@ class UserPolicy
 
         return false;
     }
+
+    public function updateRole(User $user, User $model)
+    {
+        if ($user->can('manage users') && $user->id !== $model->id) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/app/StorableEvents/User/UserDeleted.php
+++ b/app/StorableEvents/User/UserDeleted.php
@@ -8,13 +8,13 @@ use App\StorableEvents\StoredEvent;
 class UserDeleted extends StoredEvent
 {
     public function __construct(
-        public int $id,
+        public int $user_id,
     ) {
     }
 
     public function handle()
     {
-        $user = User::find($this->id);
+        $user = User::find($this->user_id);
 
         $user->delete();
     }

--- a/app/StorableEvents/User/UserRoleUpdated.php
+++ b/app/StorableEvents/User/UserRoleUpdated.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\StorableEvents\User;
+
+use App\Enum\RolesEnum;
+use App\Models\User;
+use App\StorableEvents\StoredEvent;
+
+class UserRoleUpdated extends StoredEvent
+{
+    public function __construct(
+        public int $user_id,
+        public RolesEnum $role
+    ) {
+    }
+
+    public function handle()
+    {
+        $user = User::find($this->user_id);
+
+        $user->syncRoles($this->role->value);
+    }
+}

--- a/resources/js/Pages/Dashboard/UserManagement.tsx
+++ b/resources/js/Pages/Dashboard/UserManagement.tsx
@@ -106,7 +106,7 @@ export default function UserManagement({ users, roles }: UserManagementProps) {
                                                     <SelectInput
                                                         value={user.roles[0].name}
                                                         onChange={(e) => {
-                                                            console.log(e.target.value);
+                                                            router.patch(route('users.update-role', {user: user.id}), {role: e.target.value})
                                                         }}
                                                     >
                                                         {roles.map(({ name }, index) => (

--- a/routes/users.php
+++ b/routes/users.php
@@ -7,5 +7,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('users', UserController::class)->only(['store', 'destroy']);
 
-    Route::patch('users/{user}/update-role', UserRoleController::class)->name('users.update-role');
+    Route::patch('users/{user}/update-role', [UserRoleController::class, 'update'])->name('users.update-role');
 });

--- a/tests/Feature/User/DestroyTest.php
+++ b/tests/Feature/User/DestroyTest.php
@@ -69,7 +69,7 @@ class DestroyTest extends TestCase
         Event::assertDispatchedTimes(UserDeleted::class, 1);
 
         Event::assertDispatched(function (UserDeleted $event) use ($user) {
-            return $user->id == $event->id;
+            return $user->id == $event->user_id;
         });
     }
 

--- a/tests/Feature/User/UserRoleTest.php
+++ b/tests/Feature/User/UserRoleTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature\User;
+
+use App\Enum\RolesEnum;
+use App\Models\User;
+use App\StorableEvents\User\UserRoleUpdated;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+class UserRoleTest extends TestCase
+{
+    public function test_bad_role_throws_validation()
+    {
+        $admin = User::factory()->create()->assignRole('admin');
+
+        $this->actingAs($admin);
+
+        $user = User::factory()->create()->syncRoles(RolesEnum::USER->value);
+
+        $response = $this->patch(route('users.update-role', ['user' => $user->id]), ['role' => 'bad role']);
+
+        $this->assertInstanceOf(ValidationException::class, $response->exception);
+    }
+
+    public function test_fires_user_role_updated_event()
+    {
+        Event::fake();
+
+        $admin = User::factory()->create()->assignRole('admin');
+
+        $this->actingAs($admin);
+
+        $user = User::factory()->create();
+
+        $response = $this->patch(route('users.update-role', ['user' => $user->id]), ['role' => RolesEnum::ADMIN->value]);
+
+        Event::assertDispatchedTimes(UserRoleUpdated::class, 1);
+
+        Event::assertDispatched(function (UserRoleUpdated $event) use ($user) {
+            return $user->id == $event->user_id && $event->role == RolesEnum::ADMIN;
+        });
+    }
+
+    public function test_updates_user_role()
+    {
+        $admin = User::factory()->create()->assignRole('admin');
+
+        $this->actingAs($admin);
+
+        $user = User::factory()->create()->syncRoles(RolesEnum::USER->value);
+
+        $this->assertTrue($user->hasRole(RolesEnum::USER->value));
+        $this->assertFalse($user->hasRole(RolesEnum::ADMIN->value));
+
+        $response = $this->patch(route('users.update-role', ['user' => $user->id]), ['role' => RolesEnum::ADMIN->value]);
+
+        $user->refresh();
+
+        $this->assertFalse($user->hasRole(RolesEnum::USER->value));
+        $this->assertTrue($user->hasRole(RolesEnum::ADMIN->value));
+    }
+
+    public function test_forbidden_to_update_role_of_self()
+    {
+        $admin = User::factory()->create()->assignRole('admin');
+
+        $this->actingAs($admin);
+
+        $response = $this->patch(route('users.update-role', ['user' => $admin->id]), ['role' => RolesEnum::ADMIN->value]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_user_forbidden_to_update_role()
+    {
+        $user = User::factory()->create()->assignRole('user');
+
+        $this->actingAs($user);
+
+        $otherUser = User::factory()->create();
+
+        $response = $this->patch(route('users.update-role', ['user' => $otherUser->id]), ['role' => RolesEnum::ADMIN->value]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_supervisor_forbidden_to_update_role()
+    {
+        $supervisor = User::factory()->create()->assignRole('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $user = User::factory()->create();
+
+        $response = $this->patch(route('users.update-role', ['user' => $user->id]), ['role' => RolesEnum::ADMIN->value]);
+
+        $response->assertForbidden();
+    }
+}

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -8,6 +8,56 @@ use Tests\TestCase;
 
 class UserPolicyTest extends TestCase
 {
+    public function test_admin_cant_update_role_of_self()
+    {
+        $user = User::factory()->create([
+            'name' => 'Admin',
+            'email' => 'admin@b.com',
+        ])->syncRoles('admin');
+
+        $result = $this->getPolicy()->updateRole($user, $user);
+        $this->assertFalse($result);
+    }
+
+    public function test_admin_can_update_role_of_users()
+    {
+        $user = User::factory()->create([
+            'name' => 'Admin',
+            'email' => 'admin@b.com',
+        ])->syncRoles('admin');
+
+        $otherUser = User::factory()->create();
+
+        $result = $this->getPolicy()->updateRole($user, $otherUser);
+        $this->assertTrue($result);
+    }
+
+    public function test_supervisor_cant_update_role_of_users()
+    {
+        $user = User::factory()->create([
+            'name' => 'Admin',
+            'email' => 'admin@b.com',
+        ])->syncRoles('supervisor');
+
+        $otherUser = User::factory()->create();
+
+        $result = $this->getPolicy()->updateRole($user, $otherUser);
+        $this->assertFalse($result);
+    }
+
+    public function test_user_cant_update_role_of_users()
+    {
+        $user = User::factory()->create([
+            'name' => 'Admin',
+            'email' => 'admin@b.com',
+        ])->syncRoles('user');
+
+        $otherUser = User::factory()->create();
+
+        $result = $this->getPolicy()->updateRole($user, $otherUser);
+        $this->assertFalse($result);
+    }
+
     public function test_admin_cant_delete_self()
     {
         $user = User::factory()->create([

--- a/tests/Unit/StoreableEvents/User/UserRoleUpdatedTest.php
+++ b/tests/Unit/StoreableEvents/User/UserRoleUpdatedTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace StoreableEvents\User;
+
+use App\Enum\RolesEnum;
+use App\Models\User;
+use App\StorableEvents\User\UserRoleUpdated;
+use Tests\TestCase;
+
+class UserRoleUpdatedTest extends TestCase
+{
+    public function test_updates_user_role()
+    {
+        $user = User::factory()->create()->syncRoles(RolesEnum::USER->value);
+
+        $event = new UserRoleUpdated(
+            user_id: $user->id,
+            role: RolesEnum::ADMIN
+        );
+
+        $this->assertTrue($user->hasRole(RolesEnum::USER->value));
+        $this->assertFalse($user->hasRole(RolesEnum::ADMIN->value));
+
+        $event->handle();
+
+        $user->refresh();
+
+        $this->assertFalse($user->hasRole(RolesEnum::USER->value));
+        $this->assertTrue($user->hasRole(RolesEnum::ADMIN->value));
+    }
+}


### PR DESCRIPTION
# Feature Addition [CLOSES #178]

## Summary

Adds backend for updating a user role.

## Rationale

Need to be able to update user roles. For example a temp supervisor or something.

## Design Documentation

N/A

## Changes

- User policy update role method added, same logic as delete
- User role updated event, added to update user role from enum
- Roles enum added to easier manage string value of the role

## Impact

N/A

## Testing

Feature tests added to test new patch route, and unit tests added to test event and new policy method.

## Screenshots/Video

N/A

## Checklist

- [ ] Code follows the project's coding standards

- [ ] Unit tests covering the new feature have been added

- [ ] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

N/A