### PR TITLE
#185 - Adds hazard class calculation in investigation event

### DIFF
--- a/app/Aggregates/InvestigationAggregateRoot.php
+++ b/app/Aggregates/InvestigationAggregateRoot.php
@@ -17,7 +17,6 @@ class InvestigationAggregateRoot extends AggregateRoot
             basic_causes: $investigationData->basic_causes,
             remedial_actions: $investigationData->remedial_actions,
             prevention: $investigationData->prevention,
-            hazard_class: $investigationData->hazard_class,
             risk_rank: $investigationData->risk_rank,
             resulted_in: $investigationData->resulted_in,
             substandard_acts: $investigationData->substandard_acts,

--- a/app/Data/InvestigationData.php
+++ b/app/Data/InvestigationData.php
@@ -11,7 +11,6 @@ class InvestigationData extends Data
         public string $basic_causes,
         public string $remedial_actions,
         public string $prevention,
-        public string $hazard_class,
         public int $risk_rank,
         public array $resulted_in,
         public array $substandard_acts,

--- a/app/StorableEvents/Investigation/InvestigationCreated.php
+++ b/app/StorableEvents/Investigation/InvestigationCreated.php
@@ -20,7 +20,6 @@ class InvestigationCreated extends StoredEvent
         public string $basic_causes,
         public string $remedial_actions,
         public string $prevention,
-        public string $hazard_class,
         public int $risk_rank,
         public array $resulted_in,
         public array $substandard_acts,
@@ -45,7 +44,6 @@ class InvestigationCreated extends StoredEvent
         $investigation->basic_causes = $this->basic_causes;
         $investigation->remedial_actions = $this->remedial_actions;
         $investigation->prevention = $this->prevention;
-        $investigation->hazard_class = $this->hazard_class;
         $investigation->risk_rank = $this->risk_rank;
         $investigation->resulted_in = $this->resulted_in;
 
@@ -54,6 +52,14 @@ class InvestigationCreated extends StoredEvent
         $investigation->energy_transfer_causes = $this->energy_transfer_causes;
         $investigation->personal_factors = $this->personal_factors;
         $investigation->job_factors = $this->job_factors;
+
+        if ($this->risk_rank < 3) {
+            $investigation->hazard_class = 'A';
+        } else if ($this->risk_rank < 5) {
+            $investigation->hazard_class = 'B';
+        } else {
+            $investigation->hazard_class = 'C';
+        }
 
         $investigation->save();
 

--- a/app/StorableEvents/Investigation/InvestigationCreated.php
+++ b/app/StorableEvents/Investigation/InvestigationCreated.php
@@ -55,7 +55,7 @@ class InvestigationCreated extends StoredEvent
 
         if ($this->risk_rank < 3) {
             $investigation->hazard_class = 'A';
-        } else if ($this->risk_rank < 5) {
+        } elseif ($this->risk_rank < 5) {
             $investigation->hazard_class = 'B';
         } else {
             $investigation->hazard_class = 'C';

--- a/resources/js/Pages/Investigation/Create.tsx
+++ b/resources/js/Pages/Investigation/Create.tsx
@@ -85,7 +85,6 @@ export default function Create({ incident }: { incident: Incident }) {
         basic_causes: '',
         remedial_actions: '',
         prevention: '',
-        hazard_class: 'Z',
         risk_rank: 1,
         resulted_in: [] as string[],
         substandard_acts: [] as string[],

--- a/tests/Feature/Investigation/StoreTest.php
+++ b/tests/Feature/Investigation/StoreTest.php
@@ -27,7 +27,6 @@ class StoreTest extends TestCase
             'basic_causes' => 'basic causes',
             'remedial_actions' => "remedial actions",
             'prevention' => 'prevention',
-            'hazard_class' => 'hazard class',
             'risk_rank' => 10,
             'resulted_in' => ['injury', 'burn'],
             'substandard_acts' => ['injury', 'burn'],
@@ -61,7 +60,6 @@ class StoreTest extends TestCase
             'basic_causes' => 'basic causes',
             'remedial_actions' => "remedial actions",
             'prevention' => 'prevention',
-            'hazard_class' => 'hazard class',
             'risk_rank' => 10,
             'resulted_in' => ['injury', 'burn'],
             'substandard_acts' => ['injury', 'burn'],
@@ -100,7 +98,6 @@ class StoreTest extends TestCase
             'basic_causes' => 'basic causes',
             'remedial_actions' => "remedial actions",
             'prevention' => 'prevention',
-            'hazard_class' => 'hazard class',
             'risk_rank' => 10,
             'resulted_in' => ['injury', 'burn'],
             'substandard_acts' => ['injury', 'burn'],
@@ -135,7 +132,6 @@ class StoreTest extends TestCase
             'basic_causes' => 'basic causes',
             'remedial_actions' => "remedial actions",
             'prevention' => 'prevention',
-            'hazard_class' => 'hazard class',
             'risk_rank' => 10,
             'resulted_in' => ['injury', 'burn'],
             'substandard_acts' => ['injury', 'burn'],
@@ -163,7 +159,6 @@ class StoreTest extends TestCase
             'basic_causes' => '',
             'remedial_actions' => "",
             'prevention' => '',
-            'hazard_class' => '',
             'risk_rank' => 10,
             'resulted_in' => [],
             'substandard_acts' => [],
@@ -182,7 +177,6 @@ class StoreTest extends TestCase
             'basic_causes',
             'remedial_actions',
             'prevention',
-            'hazard_class',
             'resulted_in',
             'substandard_acts',
             'substandard_conditions',
@@ -203,7 +197,6 @@ class StoreTest extends TestCase
             'basic_causes' => 'basic causes',
             'remedial_actions' => "remedial actions",
             'prevention' => 'prevention',
-            'hazard_class' => 'hazard class',
             'risk_rank' => 10,
             'resulted_in' => ['injury', 'burn'],
             'substandard_acts' => ['injury', 'burn'],
@@ -229,7 +222,6 @@ class StoreTest extends TestCase
             'basic_causes' => 'basic causes',
             'remedial_actions' => "remedial actions",
             'prevention' => 'prevention',
-            'hazard_class' => 'hazard class',
             'risk_rank' => 10,
             'resulted_in' => ['injury', 'burn'],
             'substandard_acts' => ['injury', 'burn'],
@@ -255,7 +247,6 @@ class StoreTest extends TestCase
             'basic_causes' => 'basic causes',
             'remedial_actions' => "remedial actions",
             'prevention' => 'prevention',
-            'hazard_class' => 'hazard class',
             'risk_rank' => 10,
             'resulted_in' => ['injury', 'burn'],
             'substandard_acts' => ['injury', 'burn'],
@@ -281,7 +272,6 @@ class StoreTest extends TestCase
             'basic_causes' => 'basic causes',
             'remedial_actions' => "remedial actions",
             'prevention' => 'prevention',
-            'hazard_class' => 'hazard class',
             'risk_rank' => 10,
             'resulted_in' => ['injury', 'burn'],
             'substandard_acts' => ['injury', 'burn'],
@@ -305,7 +295,6 @@ class StoreTest extends TestCase
         $this->assertEquals($investigationData->basic_causes, $investigation->basic_causes);
         $this->assertEquals($investigationData->remedial_actions, $investigation->remedial_actions);
         $this->assertEquals($investigationData->prevention, $investigation->prevention);
-        $this->assertEquals($investigationData->hazard_class, $investigation->hazard_class);
         $this->assertEquals($investigationData->risk_rank, $investigation->risk_rank);
         $this->assertEquals($investigationData->resulted_in, $investigation->resulted_in);
         $this->assertEquals($investigationData->substandard_acts, $investigation->substandard_acts);

--- a/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
+++ b/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
@@ -171,7 +171,6 @@ class InvestigationAggregateRootTest extends TestCase
                     basic_causes: 'basic causes',
                     remedial_actions: "remedial actions",
                     prevention: "prevention",
-                    hazard_class: 'hazard class',
                     risk_rank: 10,
                     resulted_in: ['injury', 'burn'],
                     substandard_acts: ['injury', 'burn'],
@@ -232,7 +231,6 @@ class InvestigationAggregateRootTest extends TestCase
             'basic_causes' => 'basic causes',
             'remedial_actions' => "remedial actions",
             'prevention' => 'prevention',
-            'hazard_class' => 'hazard class',
             'risk_rank' => 10,
             'resulted_in' => ['injury', 'burn'],
             'substandard_acts' => ['injury', 'burn'],
@@ -260,7 +258,6 @@ class InvestigationAggregateRootTest extends TestCase
         $this->assertEquals($investigationData->basic_causes, $investigation->basic_causes);
         $this->assertEquals($investigationData->remedial_actions, $investigation->remedial_actions);
         $this->assertEquals($investigationData->prevention, $investigation->prevention);
-        $this->assertEquals($investigationData->hazard_class, $investigation->hazard_class);
         $this->assertEquals($investigationData->risk_rank, $investigation->risk_rank);
         $this->assertEquals($investigationData->resulted_in, $investigation->resulted_in);
         $this->assertEquals($investigationData->substandard_acts, $investigation->substandard_acts);

--- a/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
@@ -16,6 +16,96 @@ use Tests\TestCase;
 
 class InvestigationCreatedTest extends TestCase
 {
+    public function test_event_calculates_hazard_class_a_correctly()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create(['status' => Assigned::class]);
+
+        $event = new InvestigationCreated(
+            incident_id: $incident->id,
+            immediate_causes: "immediate causes",
+            basic_causes: 'basic causes',
+            remedial_actions: "remedial actions",
+            prevention: "prevention",
+            risk_rank: 1,
+            resulted_in: ['injury', 'burn'],
+            substandard_acts: ['injury', 'burn'],
+            substandard_conditions: ['injury', 'burn'],
+            energy_transfer_causes: ['injury', 'burn'],
+            personal_factors: ['injury', 'burn'],
+            job_factors: ['injury', 'burn'],
+        );
+
+        $event->setMetaData(['user_id' => $supervisor->id]);
+
+        $event->handle();
+
+        $incident->refresh();
+
+        $this->assertEquals('A', $incident->investigations[0]->hazard_class);
+    }
+
+    public function test_event_calculates_hazard_class_b_correctly()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create(['status' => Assigned::class]);
+
+        $event = new InvestigationCreated(
+            incident_id: $incident->id,
+            immediate_causes: "immediate causes",
+            basic_causes: 'basic causes',
+            remedial_actions: "remedial actions",
+            prevention: "prevention",
+            risk_rank: 4,
+            resulted_in: ['injury', 'burn'],
+            substandard_acts: ['injury', 'burn'],
+            substandard_conditions: ['injury', 'burn'],
+            energy_transfer_causes: ['injury', 'burn'],
+            personal_factors: ['injury', 'burn'],
+            job_factors: ['injury', 'burn'],
+        );
+
+        $event->setMetaData(['user_id' => $supervisor->id]);
+
+        $event->handle();
+
+        $incident->refresh();
+
+        $this->assertEquals('B', $incident->investigations[0]->hazard_class);
+    }
+
+    public function test_event_calculates_hazard_class_c_correctly()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create(['status' => Assigned::class]);
+
+        $event = new InvestigationCreated(
+            incident_id: $incident->id,
+            immediate_causes: "immediate causes",
+            basic_causes: 'basic causes',
+            remedial_actions: "remedial actions",
+            prevention: "prevention",
+            risk_rank: 6,
+            resulted_in: ['injury', 'burn'],
+            substandard_acts: ['injury', 'burn'],
+            substandard_conditions: ['injury', 'burn'],
+            energy_transfer_causes: ['injury', 'burn'],
+            personal_factors: ['injury', 'burn'],
+            job_factors: ['injury', 'burn'],
+        );
+
+        $event->setMetaData(['user_id' => $supervisor->id]);
+
+        $event->handle();
+
+        $incident->refresh();
+
+        $this->assertEquals('C', $incident->investigations[0]->hazard_class);
+    }
+
     public function test_incident_transitions_from_assigned_to_in_review()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
@@ -28,7 +118,6 @@ class InvestigationCreatedTest extends TestCase
             basic_causes: 'basic causes',
             remedial_actions: "remedial actions",
             prevention: "prevention",
-            hazard_class: 'hazard class',
             risk_rank: 10,
             resulted_in: ['injury', 'burn'],
             substandard_acts: ['injury', 'burn'],
@@ -65,7 +154,6 @@ class InvestigationCreatedTest extends TestCase
             basic_causes: 'basic causes',
             remedial_actions: "remedial actions",
             prevention: "prevention",
-            hazard_class: 'hazard class',
             risk_rank: 10,
             resulted_in: ['injury', 'burn'],
             substandard_acts: ['injury', 'burn'],
@@ -109,7 +197,6 @@ class InvestigationCreatedTest extends TestCase
             basic_causes: 'basic causes',
             remedial_actions: "remedial actions",
             prevention: "prevention",
-            hazard_class: 'hazard class',
             risk_rank: 10,
             resulted_in: ['injury', 'burn'],
             substandard_acts: ['injury', 'burn'],
@@ -145,7 +232,6 @@ class InvestigationCreatedTest extends TestCase
             basic_causes: 'basic causes',
             remedial_actions: "remedial actions",
             prevention: "prevention",
-            hazard_class: 'hazard class',
             risk_rank: 10,
             resulted_in: ['injury', 'burn'],
             substandard_acts: ['injury', 'burn'],
@@ -170,7 +256,6 @@ class InvestigationCreatedTest extends TestCase
         $this->assertEquals($event->basic_causes, $investigation->basic_causes);
         $this->assertEquals($event->remedial_actions, $investigation->remedial_actions);
         $this->assertEquals($event->prevention, $investigation->prevention);
-        $this->assertEquals($event->hazard_class, $investigation->hazard_class);
         $this->assertEquals($event->risk_rank, $investigation->risk_rank);
         $this->assertEquals($event->resulted_in, $investigation->resulted_in);
         $this->assertEquals($event->substandard_acts, $investigation->substandard_acts);


### PR DESCRIPTION
# Feature Addition [CLOSES #185]

## Summary

Hazard class is now calculated in InvestigationCreated event based on risk rating.

## Rationale

No need for supervisor to calculate hazard class since it's based on the risk rating

## Design Documentation

NA

## Changes

- Removed hazard class from Investigation DTO and AggregateRoot
- Added calculation in InvestigationCreated handle method
- Removed hazard class from formData on investigation create page

## Impact
NA

## Testing
- Added tests for hazard class calculation
- Removed hazard class from failing tests

## Screenshots/Video

NA

## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

NA
