### PR TITLE
Status custom sort

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -18,7 +18,7 @@ class DashboardController extends Controller
 
         $incidents = Incident::latest()->where('reporters_email', $user->email)->take(5)->get();
         $incidentCount = Incident::where('reporters_email', $user->email)->count();
-        $closedCount = Incident::where('status', Closed::$name)->where('reporters_email', $user->email)->count();
+        $closedCount = Incident::whereState('status', Closed::class)->where('reporters_email', $user->email)->count();
         $unresolvedCount = $incidentCount - $closedCount;
 
         return inertia('Dashboard/UserDashboard', [
@@ -27,13 +27,14 @@ class DashboardController extends Controller
             'unresolvedCount' => $unresolvedCount,
         ]);
     }
+
     public function adminOverview()
     {
         Gate::authorize('view-admin-overview');
 
         $incidents = Incident::latest()->take(5)->get();
         $incidentCount = Incident::count();
-        $closedCount = Incident::where('status', Closed::$name)->count();
+        $closedCount = Incident::whereState('status', Closed::class)->count();
         $unresolvedCount = $incidentCount - $closedCount;
 
         return inertia('Dashboard/AdminOverview', [
@@ -52,12 +53,16 @@ class DashboardController extends Controller
 
         $unresolvedIncidents = Incident::latest()
             ->where('supervisor_id', $user->id)
-            ->where('status', Assigned::$name)
+            ->whereState('status', Assigned::class)
             ->take(5)
             ->get();
 
         $incidentCount = Incident::where('supervisor_id', $user->id)->count();
-        $closedCount = Incident::where('status', Closed::$name)->where('supervisor_id', $user->id)->count();
+
+        $closedCount = Incident::whereState('status', Closed::class)
+            ->where('supervisor_id', $user->id)
+            ->count();
+
         $unresolvedCount = $incidentCount - $closedCount;
 
         return inertia('Dashboard/SupervisorOverview', [

--- a/app/Http/Controllers/Incident/AssignedIncidentsController.php
+++ b/app/Http/Controllers/Incident/AssignedIncidentsController.php
@@ -18,8 +18,8 @@ class AssignedIncidentsController extends Controller
 
         $filters = json_decode(urldecode($request->query('filters')), true);
 
-        $sortBy = $request->string('sort_by', 'created_at');
-        $sortDirection = $request->string('sort_direction', 'desc');
+        $sortBy = $request->string('sort_by', 'status');
+        $sortDirection = $request->string('sort_direction', 'asc');
 
         $assignedIncidents = Incident::sort($sortBy, $sortDirection)
             ->filter($filters)

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -39,15 +39,15 @@ class Incident extends Model
         // Convert all boolean fields to integers
         foreach ($array as $key => $value) {
             if (is_bool($value)) {
-                $array[$key] = (int) $value;
+                $array[$key] = (int)$value;
             }
         }
 
         return array_merge($array, [
-            'id' => (string) $this->id,
-            'upei_id' => (string) $this->upei_id,
+            'id' => (string)$this->id,
+            'upei_id' => (string)$this->upei_id,
             'supervisor' => $this->supervisor ? $this->supervisor->name : null,
-            'supervisor_id' => (int) $this->supervisor_id,
+            'supervisor_id' => (int)$this->supervisor_id,
             'created_at' => $this->created_at->timestamp,
         ]);
     }
@@ -91,12 +91,30 @@ class Incident extends Model
         }
     }
 
-    public function scopeSort($query, $sortBy, $sortDirection): void
+    public function scopeSort($query, $sortBy = 'created_at', $sortDirection = 'asc'): void
     {
         if ($sortBy == 'name') {
             $query->orderBy('first_name', $sortDirection)->orderBy('last_name', $sortDirection);
+        } elseif ($sortBy == 'status') {
+            $query->orderByRaw(
+                "CASE
+                WHEN status = 'reopened' THEN 1
+                WHEN status = 'returned' THEN 2
+                WHEN status = 'opened' THEN 3
+                WHEN status = 'assigned' THEN 4
+                WHEN status = 'in review' THEN 5
+                WHEN status = 'closed' THEN 6
+                ELSE 7
+            END $sortDirection"
+            );
         } else {
             $query->orderBy($sortBy, $sortDirection);
+        }
+
+        // Always sort by created_at within what we are sorting by
+        // Unless that's what's been explicitly set
+        if ($sortBy != 'created_at') {
+            $query->orderBy('created_at', 'desc');
         }
     }
 }

--- a/app/States/IncidentStatus/Assigned.php
+++ b/app/States/IncidentStatus/Assigned.php
@@ -4,5 +4,5 @@ namespace App\States\IncidentStatus;
 
 class Assigned extends IncidentStatusState
 {
-    public static $name = 'assigned';
+    public static string $name = 'assigned';
 }

--- a/app/States/IncidentStatus/Closed.php
+++ b/app/States/IncidentStatus/Closed.php
@@ -4,5 +4,5 @@ namespace App\States\IncidentStatus;
 
 class Closed extends IncidentStatusState
 {
-    public static $name = 'closed';
+    public static string $name = 'closed';
 }

--- a/app/States/IncidentStatus/InReview.php
+++ b/app/States/IncidentStatus/InReview.php
@@ -4,5 +4,5 @@ namespace App\States\IncidentStatus;
 
 class InReview extends IncidentStatusState
 {
-    public static $name = 'in review';
+    public static string $name = 'in review';
 }

--- a/app/States/IncidentStatus/Opened.php
+++ b/app/States/IncidentStatus/Opened.php
@@ -4,5 +4,5 @@ namespace App\States\IncidentStatus;
 
 class Opened extends IncidentStatusState
 {
-    public static $name = 'opened';
+    public static string $name = 'opened';
 }

--- a/app/States/IncidentStatus/Reopened.php
+++ b/app/States/IncidentStatus/Reopened.php
@@ -4,5 +4,5 @@ namespace App\States\IncidentStatus;
 
 class Reopened extends IncidentStatusState
 {
-    public static $name = 'reopened';
+    public static string $name = 'reopened';
 }

--- a/resources/js/Pages/Incident/Index.tsx
+++ b/resources/js/Pages/Incident/Index.tsx
@@ -148,10 +148,10 @@ export default function Index({
     const resetFilters = () => setFilters(initialFilters);
 
     const handleSortCycle = (sortBy: SortBy) => {
-        if (sortBy !== sortedBy || sortedDirection === 'asc') {
-            setSortedDirection('desc');
-        } else {
+        if (sortBy !== sortedBy || sortedDirection === 'desc') {
             setSortedDirection('asc');
+        } else {
+            setSortedDirection('desc');
         }
 
         setSortedBy(sortBy);

--- a/tests/Unit/Models/IncidentTest.php
+++ b/tests/Unit/Models/IncidentTest.php
@@ -5,10 +5,32 @@ namespace Tests\Unit\Models;
 use App\Models\Incident;
 use App\Models\Investigation;
 use App\Models\User;
+use App\States\IncidentStatus\Assigned;
+use App\States\IncidentStatus\Closed;
+use App\States\IncidentStatus\InReview;
+use App\States\IncidentStatus\Opened;
+use App\States\IncidentStatus\Reopened;
+use App\States\IncidentStatus\Returned;
 use Tests\TestCase;
 
 class IncidentTest extends TestCase
 {
+    public function test_sort_scope_status_sorts_by_custom_order()
+    {
+        Incident::factory()->create(['status' => Assigned::class]);
+        Incident::factory()->create(['status' => Closed::class]);
+        Incident::factory()->create(['status' => InReview::class]);
+        Incident::factory()->create(['status' => Opened::class]);
+        Incident::factory()->create(['status' => Reopened::class]);
+        Incident::factory()->create(['status' => Returned::class]);
+
+        $sortedIncidents = Incident::sort('status')->get();
+
+        $sortedIncidentsStatus = $sortedIncidents->pluck('status')->toArray();
+
+        $this->assertEquals(['reopened', 'returned', 'opened', 'assigned', 'in review','closed'], $sortedIncidentsStatus);
+    }
+
     public function test_incident_has_one_supervisor_relation()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');


### PR DESCRIPTION
# Feature Addition [CLOSES #196]

## Summary

Adds a custom sort query on status sort requests.

## Rationale

Status makes more sense ordered by the flow of status instead of lexographically.

## Design Documentation

N/A

## Changes

- Status is now sorted in the following order
  1. reopened
  2. returned
  3. opened
  4. assigned
  5. in review
  6. closed

## Impact

N/A

## Testing

Unit test added to test custom sort scope.

## Screenshots/Video

N/A

## Checklist

- [ ] Code follows the project's coding standards

- [ ] Unit tests covering the new feature have been added

- [ ] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

N/A