### PR TITLE
Supervisor Request Review

### DIFF
--- a/app/Aggregates/IncidentAggregateRoot.php
+++ b/app/Aggregates/IncidentAggregateRoot.php
@@ -12,6 +12,7 @@ use App\StorableEvents\Comment\CommentCreated;
 use App\StorableEvents\Incident\IncidentClosed;
 use App\StorableEvents\Incident\IncidentCreated;
 use App\StorableEvents\Incident\IncidentReopened;
+use App\StorableEvents\Incident\IncidentReviewRequested;
 use App\StorableEvents\Incident\InvestigationReturned;
 use App\StorableEvents\Incident\SupervisorAssigned;
 use App\StorableEvents\Incident\SupervisorUnassigned;
@@ -68,6 +69,13 @@ class IncidentAggregateRoot extends AggregateRoot
     public function unassignSupervisor()
     {
         $this->recordThat(new SupervisorUnassigned);
+
+        return $this;
+    }
+
+    public function requestReview()
+    {
+        $this->recordThat(new IncidentReviewRequested);
 
         return $this;
     }

--- a/app/Http/Controllers/Incident/IncidentController.php
+++ b/app/Http/Controllers/Incident/IncidentController.php
@@ -97,6 +97,7 @@ class IncidentController extends Controller
         return Inertia::render('Incident/Show', [
             'incident' => $incident->load(['comments.user', 'supervisor']),
             'supervisors' => $supervisors,
+            'canRequestReview' => $user->can('requestReview', $incident)
         ]);
     }
 

--- a/app/Http/Controllers/Incident/IncidentStatusController.php
+++ b/app/Http/Controllers/Incident/IncidentStatusController.php
@@ -9,6 +9,17 @@ use Illuminate\Http\Request;
 
 class IncidentStatusController extends Controller
 {
+    public function requestReview(Incident $incident)
+    {
+        $this->authorize('requestReview', $incident);
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->requestReview()
+            ->persist();
+
+        return back();
+    }
+
     public function returnInvestigation(Incident $incident)
     {
         $this->authorize('performAdminActions', Incident::class);

--- a/app/Notifications/Incident/IncidentReviewRequest.php
+++ b/app/Notifications/Incident/IncidentReviewRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Notifications\Incident;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\VonageMessage;
+use Illuminate\Notifications\Notification;
+
+class IncidentReviewRequest extends Notification
+{
+    use Queueable;
+
+    public string $message;
+    public string $url;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $incidentId,
+        public User $supervisor,
+    ) {
+        $this->message = "{$this->supervisor->name} has requested an incident follow up review.";
+        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database', 'vonage'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Incident Follow Up Review Request')
+            ->markdown('mail.incident-review-request', ['url' => $this->url]);
+    }
+
+    /**
+     * Get the Vonage / SMS representation of the notification.
+     */
+    public function toVonage(object $notifiable): VonageMessage
+    {
+        return (new VonageMessage)
+            ->content($this->message);
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'url' => $this->url,
+            'message' => $this->message,
+        ];
+    }
+}

--- a/app/StorableEvents/Incident/IncidentReviewRequested.php
+++ b/app/StorableEvents/Incident/IncidentReviewRequested.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\StorableEvents\Incident;
+
+use App\Enum\CommentType;
+use App\Models\Comment;
+use App\Models\Incident;
+use App\Models\User;
+use App\Notifications\Incident\IncidentReviewRequest;
+use App\States\IncidentStatus\InReview;
+use App\StorableEvents\StoredEvent;
+use Illuminate\Support\Facades\Notification;
+
+class IncidentReviewRequested extends StoredEvent
+{
+    public function __construct()
+    {
+    }
+
+    public function handle()
+    {
+        $incident = Incident::find($this->aggregateRootUuid());
+
+        $incident->status->transitionTo(InReview::class);
+
+        $incident->save();
+
+        $comment = new Comment;
+
+        $comment->user_id = $this->metaData['user_id'];
+        $comment->type = CommentType::ACTION;
+        $comment->content = 'Incident review was requested.';
+
+        $comment->commentable()->associate($incident);
+
+        $comment->save();
+    }
+
+    public function react()
+    {
+        $admins = User::role('admin')->get();
+
+        $supervisor = User::find($this->metaData['user_id']);
+
+        Notification::send($admins, new IncidentReviewRequest($this->aggregateRootUuid(), $supervisor));
+    }
+}

--- a/resources/js/Pages/Incident/Partials/IncidentSupervisorActions.tsx
+++ b/resources/js/Pages/Incident/Partials/IncidentSupervisorActions.tsx
@@ -7,9 +7,10 @@ import dateTimeFormat from '@/Filters/dateTimeFormat';
 
 interface SupervisorActionsProps {
     incident: Incident;
+    canRequestReview: boolean;
 }
 
-export default function IncidentSupervisorActions({ incident }: SupervisorActionsProps) {
+export default function IncidentSupervisorActions({ incident, canRequestReview }: SupervisorActionsProps) {
     return (
         <div className="lg:col-start-3 lg:row-end-1 bg-white">
             <div className="rounded-lg  shadow-sm ring-1 ring-gray-900/5">
@@ -59,6 +60,18 @@ export default function IncidentSupervisorActions({ incident }: SupervisorAction
                             >
                                 Submit Root Cause Analysis
                             </Link>
+                            {canRequestReview && (
+                                <Link
+                                    href={route('incidents.request-review', {
+                                        incident: incident.id,
+                                    })}
+                                    method="patch"
+                                    as="button"
+                                    className="text-center rounded-md bg-upei-red-500 px-3 py-2  text-sm font-semibold text-white shadow-sm hover:bg-upei-red-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-upei-red-600"
+                                >
+                                    Request Review
+                                </Link>
+                            )}
                         </div>
                     )}
                 </div>

--- a/resources/js/Pages/Incident/Show.tsx
+++ b/resources/js/Pages/Incident/Show.tsx
@@ -13,9 +13,10 @@ import { IncidentStatus } from '@/Enums/IncidentStatus';
 interface ShowProps extends PageProps {
     incident: Incident;
     supervisors: User[];
+    canRequestReview: boolean;
 }
 
-export default function Show({ auth, incident, supervisors }: PageProps<ShowProps>) {
+export default function Show({ auth, incident, supervisors, canRequestReview }: PageProps<ShowProps>) {
     const user = auth.user;
 
     const { data, setData, post, processing, reset } = useForm({
@@ -51,6 +52,7 @@ export default function Show({ auth, incident, supervisors }: PageProps<ShowProp
                                 incident.status === IncidentStatus.ASSIGNED && (
                                     <IncidentSupervisorActions
                                         incident={incident}
+                                        canRequestReview={canRequestReview}
                                     ></IncidentSupervisorActions>
                                 )}
 

--- a/resources/views/mail/incident-review-request.blade.php
+++ b/resources/views/mail/incident-review-request.blade.php
@@ -1,0 +1,12 @@
+<x-mail::message>
+# Incident Follow Up Review Request
+
+Your review has been requested on the below incident and its follow up.
+
+<x-mail::button :url="$url">
+View Incident
+</x-mail::button>
+
+Thanks,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/routes/incidents.php
+++ b/routes/incidents.php
@@ -24,6 +24,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::patch('/incidents/{incident}/return', [IncidentStatusController::class, 'returnInvestigation'])->name('incidents.return-investigation');
     Route::patch('/incidents/{incident}/close', [IncidentStatusController::class, 'closeIncident'])->name('incidents.close');
     Route::patch('/incidents/{incident}/reopen', [IncidentStatusController::class, 'reopenIncident'])->name('incidents.reopen');
+    Route::patch('/incidents/{incident}/request-review', [IncidentStatusController::class, 'requestReview'])->name('incidents.request-review');
 
     Route::resource('incidents', IncidentController::class)->except([
         'create',

--- a/tests/Feature/Incident/StatusTest.php
+++ b/tests/Feature/Incident/StatusTest.php
@@ -4,15 +4,411 @@ namespace Tests\Feature\Incident;
 
 use App\Enum\CommentType;
 use App\Models\Incident;
+use App\Models\Investigation;
+use App\Models\RootCauseAnalysis;
 use App\Models\User;
+use App\Notifications\Incident\IncidentReviewRequest;
+use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\Closed;
 use App\States\IncidentStatus\InReview;
 use App\States\IncidentStatus\Reopened;
 use App\States\IncidentStatus\Returned;
+use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class StatusTest extends TestCase
 {
+    public function test_supervisor_forbidden_to_request_review_if_not_assigned_to_incident()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_supervisor_forbidden_to_request_review_if_not_assigned_state()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_supervisor_forbidden_to_request_review_if_latest_investigation_and_root_cause_analyses_not_his()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_supervisor_forbidden_to_request_review_if_latest_root_cause_analyses_not_his()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_supervisor_forbidden_to_request_review_if_latest_investigation_not_his()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_supervisor_forbidden_to_request_review_if_no_investigations_and_no_root_cause_analyses()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_supervisor_forbidden_to_request_review_if_no_root_cause_analyses()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_supervisor_forbidden_to_request_review_if_no_investigations()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_user_forbidden_to_request_review()
+    {
+        $user = User::factory()->create()->syncRoles('user');
+
+        $this->actingAs($user);
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_admin_forbidden_to_request_review()
+    {
+        $admin = User::factory()->create()->syncRoles('admin');
+
+        $this->actingAs($admin);
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $response->assertForbidden();
+    }
+
+    public function test_request_review_stores_request_notification_in_database()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        Notification::assertNothingSent();
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $incident->refresh();
+
+        Notification::assertCount(3);
+
+        Notification::assertSentTo(
+            $admins,
+            function (IncidentReviewRequest $notification, array $channels) use ($incident, $admins, $supervisor) {
+                $databaseStore = $notification->toArray($admins->first());
+
+                $this->assertEquals(route('incidents.show', $incident->id), $databaseStore['url']);
+
+                return array_key_exists('message', $databaseStore);
+            }
+        );
+    }
+
+    public function test_request_review_sends_request_notification_to_admin()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        Notification::assertNothingSent();
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        Notification::assertCount(3);
+
+        Notification::assertSentTo($admins, IncidentReviewRequest::class);
+
+        Notification::assertSentTo(
+            $admins,
+            function (IncidentReviewRequest $notification, array $channels) use ($incident, $supervisor) {
+                return $notification->incidentId === $incident->id && $notification->supervisor->id === $supervisor->id;
+            }
+        );
+    }
+
+    public function test_request_review_adds_review_requested_comment()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $incident->refresh();
+
+        $this->assertCount(1, $incident->comments);
+
+        $comment = $incident->comments->first();
+
+        $this->assertEquals(CommentType::ACTION, $comment->type);
+        $this->assertStringContainsStringIgnoringCase('review', $comment->content);
+        $this->assertStringContainsStringIgnoringCase('requested', $comment->content);
+        $this->assertStringContainsStringIgnoringCase('incident', $comment->content);
+    }
+
+    public function test_request_review_transitions_incident_from_assigned_to_in_review()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $response = $this->patch(route('incidents.request-review', ['incident' => $incident]));
+
+        $incident->refresh();
+
+        $this->assertEquals(InReview::class, $incident->status::class);
+    }
+
     public function test_adds_returned_comment()
     {
         $admin = User::factory()->create()->syncRoles('admin');

--- a/tests/Feature/Investigation/StoreTest.php
+++ b/tests/Feature/Investigation/StoreTest.php
@@ -9,7 +9,6 @@ use App\Models\Investigation;
 use App\Models\User;
 use App\Notifications\Investigation\InvestigationSubmitted;
 use App\States\IncidentStatus\Assigned;
-use App\States\IncidentStatus\InReview;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\ValidationException;
 use Tests\TestCase;

--- a/tests/Feature/Investigation/StoreTest.php
+++ b/tests/Feature/Investigation/StoreTest.php
@@ -16,35 +16,6 @@ use Tests\TestCase;
 
 class StoreTest extends TestCase
 {
-    public function test_incident_transitions_from_assigned_to_in_review()
-    {
-        $this->markTestSkipped('Functionality under changes.');
-
-        $supervisor = User::factory()->create()->syncRoles('supervisor');
-
-        $incident = Incident::factory()->create(['status' => Assigned::class, 'supervisor_id' => $supervisor->id]);
-
-        $investigationData = InvestigationData::from([
-            'immediate_causes' => "immediate causes",
-            'basic_causes' => 'basic causes',
-            'remedial_actions' => "remedial actions",
-            'prevention' => 'prevention',
-            'risk_rank' => 10,
-            'resulted_in' => ['injury', 'burn'],
-            'substandard_acts' => ['injury', 'burn'],
-            'substandard_conditions' => ['injury', 'burn'],
-            'energy_transfer_causes' => ['injury', 'burn'],
-            'personal_factors' => ['injury', 'burn'],
-            'job_factors' => ['injury', 'burn'],
-        ]);
-
-        $response = $this->actingAs($supervisor)->post(route('incidents.investigations.store', $incident), $investigationData->toArray());
-
-        $incident->refresh();
-
-        $this->assertEquals(InReview::class, $incident->status::class);
-    }
-
     public function test_sends_received_notification_to_admin()
     {
         Notification::fake();

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -48,6 +48,7 @@ class IncidentAggregateRootTest extends TestCase
         $incident = Incident::factory()->create([
             'status' => Assigned::class,
         ]);
+
         Notification::assertNothingSent();
 
         IncidentAggregateRoot::retrieve($incident->id)

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -11,6 +11,7 @@ use App\Exceptions\UserNotSupervisorException;
 use App\Mail\IncidentReceived;
 use App\Models\Incident;
 use App\Models\User;
+use App\Notifications\Incident\IncidentReviewRequest;
 use App\Notifications\Incident\IncidentSubmitted;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\Closed;
@@ -28,11 +29,138 @@ use App\StorableEvents\Incident\SupervisorUnassigned;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;
+use Spatie\ModelStates\Exceptions\TransitionNotFound;
 use Tests\TestCase;
 
 class IncidentAggregateRootTest extends TestCase
 {
-    public function test_sets_returned_status()
+    public function test_stores_request_notification_in_database()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'status' => Assigned::class,
+        ]);
+        Notification::assertNothingSent();
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->requestReview()
+            ->persist();
+
+        $incident->refresh();
+
+        Notification::assertCount(3);
+
+        Notification::assertSentTo(
+            $admins,
+            function (IncidentReviewRequest $notification, array $channels) use ($incident, $admins, $supervisor) {
+                $databaseStore = $notification->toArray($admins->first());
+
+                $this->assertEquals(route('incidents.show', $incident->id), $databaseStore['url']);
+
+                return array_key_exists('message', $databaseStore);
+            }
+        );
+    }
+
+    public function test_request_review_sends_request_notification_to_admin()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'status' => Assigned::class,
+        ]);
+
+        Notification::assertNothingSent();
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->requestReview()
+            ->persist();
+
+        Notification::assertCount(3);
+
+        Notification::assertSentTo($admins, IncidentReviewRequest::class);
+
+        Notification::assertSentTo(
+            $admins,
+            function (IncidentReviewRequest $notification, array $channels) use ($incident, $supervisor) {
+                return $notification->incidentId === $incident->id && $notification->supervisor->id === $supervisor->id;
+            }
+        );
+    }
+
+    public function test_request_review_adds_review_requested_comment()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'status' => Assigned::class,
+        ]);
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->requestReview()
+            ->persist();
+
+        $incident->refresh();
+
+        $this->assertCount(1, $incident->comments);
+
+        $comment = $incident->comments->first();
+
+        $this->assertEquals(CommentType::ACTION, $comment->type);
+        $this->assertStringContainsStringIgnoringCase('review', $comment->content);
+        $this->assertStringContainsStringIgnoringCase('requested', $comment->content);
+        $this->assertStringContainsStringIgnoringCase('incident', $comment->content);
+    }
+
+    public function test_request_review_throws_if_not_assigned()
+    {
+        $this->expectException(TransitionNotFound::class);
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create(['status' => Opened::class]);
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->requestReview()
+            ->persist();
+    }
+
+    public function test_request_review_transitions_incident_from_assigned_to_in_review()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'status' => Assigned::class,
+        ]);
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->requestReview()
+            ->persist();
+
+        $incident->refresh();
+
+        $this->assertEquals(InReview::class, $incident->status::class);
+    }
+
+    public function test_return_investigation_sets_returned_status()
     {
         $incident = Incident::factory()->create([
             'status' => InReview::class,
@@ -47,7 +175,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertEquals(Returned::class, $incident->status::class);
     }
 
-    public function test_adds_returned_comment()
+    public function test_return_investigation_adds_returned_comment()
     {
         $incident = Incident::factory()->create([
             'status' => InReview::class,
@@ -68,7 +196,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertStringContainsStringIgnoringCase('incident', $comment->content);
     }
 
-    public function test_fires_investigation_returned_event()
+    public function test_return_investigation_fires_investigation_returned_event()
     {
         $incident = Incident::factory()->create([
             'status' => InReview::class,
@@ -83,7 +211,7 @@ class IncidentAggregateRootTest extends TestCase
             ]);
     }
 
-    public function test_adds_reopened_comment()
+    public function test_reopen_incident_adds_reopened_comment()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
 
@@ -107,7 +235,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertStringContainsStringIgnoringCase('incident', $comment->content);
     }
 
-    public function test_adds_closed_comment()
+    public function test_close_incident_adds_closed_comment()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
 
@@ -131,7 +259,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertStringContainsStringIgnoringCase('incident', $comment->content);
     }
 
-    public function test_adds_unassigned_comment()
+    public function test_unassign_supervisor_adds_unassigned_comment()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
 
@@ -155,7 +283,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertStringContainsStringIgnoringCase('incident', $comment->content);
     }
 
-    public function test_throws_user_not_supervisor_if_id_not_supervisor()
+    public function test_assign_supervisor_throws_user_not_supervisor_if_id_not_supervisor()
     {
         $this->expectException(UserNotSupervisorException::class);
 
@@ -168,7 +296,7 @@ class IncidentAggregateRootTest extends TestCase
             ->persist();
     }
 
-    public function test_adds_assigned_comment_on_supervisor_assigned()
+    public function test_assign_supervisor_adds_assigned_comment()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
 
@@ -192,7 +320,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertStringContainsStringIgnoringCase($supervisor->name, $comment->content);
     }
 
-    public function test_add_comment_adds_comment_to_model()
+    public function test_add_comment_adds_comment_to_incident()
     {
         $incident = Incident::factory()->create();
 
@@ -220,7 +348,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertEquals(get_class($incident), $comment->commentable_type);
     }
 
-    public function test_comment_created_event_fired()
+    public function test_add_comment_fires_comment_created_event()
     {
         $incident = Incident::factory()->create();
 
@@ -242,7 +370,7 @@ class IncidentAggregateRootTest extends TestCase
             ]);
     }
 
-    public function test_closed_incident_event_fired()
+    public function test_close_incident_fires_incident_closed_event()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
         $incident = Incident::factory()->create([
@@ -260,7 +388,7 @@ class IncidentAggregateRootTest extends TestCase
             ]);
     }
 
-    public function test_close_incident()
+    public function test_close_incident_sets_incident_status_to_closed()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
 
@@ -280,7 +408,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertEquals(Closed::class, $incident->status::class);
     }
 
-    public function test_reopened_incident_event_fired()
+    public function test_reopened_incident_fires_incident_reopened_event()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
         $incident = Incident::factory()->create([
@@ -298,7 +426,7 @@ class IncidentAggregateRootTest extends TestCase
             ]);
     }
 
-    public function test_reopen_incident()
+    public function test_reopen_incident_sets_status_to_reopened()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
 
@@ -318,7 +446,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertEquals(Reopened::class, $incident->status::class);
     }
 
-    public function test_unassigned_supervisor_event_fired()
+    public function test_unassigned_supervisor_fires_supervisor_unassigned_event()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
         $incident = Incident::factory()->create([
@@ -336,7 +464,7 @@ class IncidentAggregateRootTest extends TestCase
             ]);
     }
 
-    public function test_unassign_supervisor_from_incident()
+    public function test_unassign_supervisor_unassigns_supervisor_from_incident()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
         $incident = Incident::factory()->create([
@@ -355,7 +483,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertEquals(Opened::class, $incident->status::class);
     }
 
-    public function test_assigned_supervisor_event_fired()
+    public function test_assigned_supervisor_fires_supervisor_assigned_event()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
         $incident = Incident::factory()->create();
@@ -369,7 +497,7 @@ class IncidentAggregateRootTest extends TestCase
             ]);
     }
 
-    public function test_assign_supervisor_to_incident()
+    public function test_assign_supervisor_assigns_supervisor_to_incident()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
 
@@ -388,7 +516,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertInstanceOf(User::class, $incident->supervisor);
     }
 
-    public function test_adds_created_comment()
+    public function test_create_incident_adds_created_comment()
     {
         $incidentData = IncidentData::from([
             'anonymous' => false,
@@ -437,7 +565,7 @@ class IncidentAggregateRootTest extends TestCase
 
     }
 
-    public function test_fires_incident_created_event()
+    public function test_create_incident_fires_incident_created_event()
     {
         $incidentData = IncidentData::from([
             'anonymous' => false,
@@ -496,7 +624,7 @@ class IncidentAggregateRootTest extends TestCase
             ]);
     }
 
-    public function test_incident_uuid_is_aggregate_uuid()
+    public function test_create_incident_stored_incident_uuid_is_aggregate_uuid()
     {
         $incidentData = IncidentData::from([
             'anonymous' => false,
@@ -538,7 +666,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertEquals($aggregate->uuid(), $incident->id);
     }
 
-    public function test_stores_incident()
+    public function test_create_incident_stores_incident()
     {
         $incidentData = IncidentData::from([
             'anonymous' => false,

--- a/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
+++ b/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
@@ -18,39 +18,6 @@ use Tests\TestCase;
 
 class InvestigationAggregateRootTest extends TestCase
 {
-    public function test_incident_transitions_from_assigned_to_in_review()
-    {
-        $this->markTestSkipped('Functionality under changes.');
-
-        $supervisor = User::factory()->create()->syncRoles('supervisor');
-        $this->actingAs($supervisor);
-
-        $incident = Incident::factory()->create(['status' => Assigned::class]);
-
-        $investigationData = InvestigationData::from([
-            'immediate_causes' => "immediate causes",
-            'basic_causes' => 'basic causes',
-            'remedial_actions' => "remedial actions",
-            'prevention' => 'prevention',
-            'hazard_class' => 'hazard class',
-            'risk_rank' => 10,
-            'resulted_in' => ['injury', 'burn'],
-            'substandard_acts' => ['injury', 'burn'],
-            'substandard_conditions' => ['injury', 'burn'],
-            'energy_transfer_causes' => ['injury', 'burn'],
-            'personal_factors' => ['injury', 'burn'],
-            'job_factors' => ['injury', 'burn'],
-        ]);
-
-        InvestigationAggregateRoot::retrieve(Str::uuid()->toString())
-            ->createInvestigation($investigationData, $incident)
-            ->persist();
-
-        $incident->refresh();
-
-        $this->assertEquals(InReview::class, $incident->status::class);
-    }
-
     public function test_sends_received_notification_to_admin()
     {
         Notification::fake();

--- a/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
+++ b/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
@@ -10,7 +10,6 @@ use App\Models\Investigation;
 use App\Models\User;
 use App\Notifications\Investigation\InvestigationSubmitted;
 use App\States\IncidentStatus\Assigned;
-use App\States\IncidentStatus\InReview;
 use App\StorableEvents\Investigation\InvestigationCreated;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;

--- a/tests/Unit/Policies/IncidentPolicyTest.php
+++ b/tests/Unit/Policies/IncidentPolicyTest.php
@@ -3,12 +3,257 @@
 namespace Tests\Unit\Policies;
 
 use App\Models\Incident;
+use App\Models\Investigation;
+use App\Models\RootCauseAnalysis;
 use App\Models\User;
 use App\Policies\IncidentPolicy;
+use App\States\IncidentStatus\Assigned;
 use Tests\TestCase;
 
 class IncidentPolicyTest extends TestCase
 {
+    public function test_supervisor_can_request_review()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $result = $this->getPolicy()->requestReview($supervisor, $incident);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_supervisor_cant_request_review_if_not_assigned_to_incident()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $result = $this->getPolicy()->requestReview($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_cant_request_review_if_not_assigned_state()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $result = $this->getPolicy()->requestReview($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_cant_request_review_if_latest_investigation_and_root_cause_analyses_not_his()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+        ]);
+
+        $result = $this->getPolicy()->requestReview($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_cant_request_review_if_latest_root_cause_analyses_not_his()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+        ]);
+
+        $result = $this->getPolicy()->requestReview($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_cant_request_review_if_latest_investigation_not_his()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $result = $this->getPolicy()->requestReview($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_cant_request_review_if_no_investigations_and_no_root_cause_analyses()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $result = $this->getPolicy()->requestReview($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_cant_request_review_if_no_root_cause_analyses()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $result = $this->getPolicy()->requestReview($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_cant_request_review_if_no_investigations()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $result = $this->getPolicy()->requestReview($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_admin_cant_request_review()
+    {
+        $admin = User::factory()->create()->syncRoles('admin');
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $result = $this->getPolicy()->requestReview($admin, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_user_cant_request_review()
+    {
+        $user = User::factory()->create()->syncRoles('user');
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $rca = RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $result = $this->getPolicy()->requestReview($user, $incident);
+
+        $this->assertFalse($result);
+    }
+
     public function test_admin_can_search_for_all_incidents()
     {
         $admin = User::factory()->create()->syncRoles('admin');

--- a/tests/Unit/StoreableEvents/Incident/IncidentReopenedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReopenedTest.php
@@ -6,12 +6,30 @@ use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\User;
 use App\States\IncidentStatus\Closed;
+use App\States\IncidentStatus\Opened;
 use App\States\IncidentStatus\Reopened;
 use App\StorableEvents\Incident\IncidentReopened;
+use Spatie\ModelStates\Exceptions\TransitionNotFound;
 use Tests\TestCase;
 
 class IncidentReopenedTest extends TestCase
 {
+    public function test_throws_if_not_closed()
+    {
+        $this->expectException(TransitionNotFound::class);
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Opened::class,
+        ]);
+
+        $event = new IncidentReopened;
+        $event->setAggregateRootUuid($incident->id);
+        $event->handle();
+    }
+
     public function test_adds_reopened_comment()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');

--- a/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
@@ -40,8 +40,6 @@ class IncidentReviewRequestedTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, IncidentReviewRequest::class);
-
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequest $notification, array $channels) use ($incident, $admins, $supervisor) {
@@ -78,8 +76,6 @@ class IncidentReviewRequestedTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, IncidentReviewRequest::class);
-
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequest $notification, array $channels) use ($incident, $supervisor) {
@@ -90,11 +86,9 @@ class IncidentReviewRequestedTest extends TestCase
 
     public function test_adds_review_requested_comment()
     {
-        $this->expectException(TransitionNotFound::class);
-
         $supervisor = User::factory()->create()->syncRoles('supervisor');
 
-        $incident = Incident::factory()->create(['status' => Opened::class]);
+        $incident = Incident::factory()->create(['status' => Assigned::class]);
 
         $event = new IncidentReviewRequested;
 

--- a/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace StoreableEvents\Incident;
+
+use App\Enum\CommentType;
+use App\Models\Incident;
+use App\Models\User;
+use App\Notifications\Incident\IncidentReviewRequest;
+use App\States\IncidentStatus\Assigned;
+use App\States\IncidentStatus\InReview;
+use App\States\IncidentStatus\Opened;
+use App\StorableEvents\Incident\IncidentReviewRequested;
+use Illuminate\Support\Facades\Notification;
+use Spatie\ModelStates\Exceptions\TransitionNotFound;
+use Tests\TestCase;
+
+class IncidentReviewRequestedTest extends TestCase
+{
+    public function test_stores_request_notification_in_database()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create(['status' => Assigned::class]);
+
+        $event = new IncidentReviewRequested;
+
+        $event->setMetaData(['user_id' => $supervisor->id]);
+
+        $event->setAggregateRootUuid($incident->id);
+
+        Notification::assertNothingSent();
+
+        $event->react();
+
+        Notification::assertCount(3);
+
+        Notification::assertSentTo($admins, IncidentReviewRequest::class);
+
+        Notification::assertSentTo(
+            $admins,
+            function (IncidentReviewRequest $notification, array $channels) use ($incident, $admins, $supervisor) {
+                $databaseStore = $notification->toArray($admins->first());
+
+                $this->assertEquals(route('incidents.show', $incident->id), $databaseStore['url']);
+
+                return array_key_exists('message', $databaseStore);
+            }
+        );
+    }
+
+    public function test_sends_request_notification_to_admin()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create(['status' => Assigned::class]);
+
+        $event = new IncidentReviewRequested;
+
+        $event->setMetaData(['user_id' => $supervisor->id]);
+
+        $event->setAggregateRootUuid($incident->id);
+
+        Notification::assertNothingSent();
+
+        $event->react();
+
+        Notification::assertCount(3);
+
+        Notification::assertSentTo($admins, IncidentReviewRequest::class);
+
+        Notification::assertSentTo(
+            $admins,
+            function (IncidentReviewRequest $notification, array $channels) use ($incident, $supervisor) {
+                return $notification->incidentId === $incident->id && $notification->supervisor->id === $supervisor->id;
+            }
+        );
+    }
+
+    public function test_adds_review_requested_comment()
+    {
+        $this->expectException(TransitionNotFound::class);
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create(['status' => Opened::class]);
+
+        $event = new IncidentReviewRequested;
+
+        $event->setMetaData(['user_id' => $supervisor->id]);
+        $event->setAggregateRootUuid($incident->id);
+
+        $event->handle();
+
+        $incident->refresh();
+
+        $this->assertCount(1, $incident->comments);
+
+        $comment = $incident->comments->first();
+
+        $this->assertEquals(CommentType::ACTION, $comment->type);
+        $this->assertStringContainsStringIgnoringCase('review', $comment->content);
+        $this->assertStringContainsStringIgnoringCase('requested', $comment->content);
+        $this->assertStringContainsStringIgnoringCase('incident', $comment->content);
+    }
+
+    public function test_throws_if_not_assigned()
+    {
+        $this->expectException(TransitionNotFound::class);
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create(['status' => Opened::class]);
+
+        $event = new IncidentReviewRequested;
+
+        $event->setMetaData(['user_id' => $supervisor->id]);
+        $event->setAggregateRootUuid($incident->id);
+
+        $event->handle();
+    }
+
+    public function test_incident_transitions_from_assigned_to_in_review()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create(['status' => Assigned::class]);
+
+        $event = new IncidentReviewRequested;
+
+        $event->setMetaData(['user_id' => $supervisor->id]);
+        $event->setAggregateRootUuid($incident->id);
+
+        $event->handle();
+
+        $incident->refresh();
+
+        $this->assertEquals(InReview::class, $incident->status::class);
+    }
+}

--- a/tests/Unit/StoreableEvents/Incident/InvestigationReturnedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/InvestigationReturnedTest.php
@@ -4,13 +4,28 @@ namespace StoreableEvents\Incident;
 
 use App\Enum\CommentType;
 use App\Models\Incident;
+use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\InReview;
 use App\States\IncidentStatus\Returned;
 use App\StorableEvents\Incident\InvestigationReturned;
+use Spatie\ModelStates\Exceptions\TransitionNotFound;
 use Tests\TestCase;
 
 class InvestigationReturnedTest extends TestCase
 {
+    public function test_throws_if_not_in_review()
+    {
+        $this->expectException(TransitionNotFound::class);
+
+        $incident = Incident::factory()->create([
+            'status' => Assigned::class,
+        ]);
+
+        $event = new InvestigationReturned;
+        $event->setAggregateRootUuid($incident->id);
+        $event->handle();
+    }
+
     public function test_adds_returned_comment()
     {
         $incident = Incident::factory()->create([

--- a/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
@@ -8,7 +8,6 @@ use App\Models\Investigation;
 use App\Models\User;
 use App\Notifications\Investigation\InvestigationSubmitted;
 use App\States\IncidentStatus\Assigned;
-use App\States\IncidentStatus\InReview;
 use App\StorableEvents\Investigation\InvestigationCreated;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Str;

--- a/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
@@ -106,38 +106,6 @@ class InvestigationCreatedTest extends TestCase
         $this->assertEquals('C', $incident->investigations[0]->hazard_class);
     }
 
-    public function test_incident_transitions_from_assigned_to_in_review()
-    {
-        $this->markTestSkipped('Functionality under changes.');
-
-        $supervisor = User::factory()->create()->syncRoles('supervisor');
-
-        $incident = Incident::factory()->create(['status' => Assigned::class]);
-
-        $event = new InvestigationCreated(
-            incident_id: $incident->id,
-            immediate_causes: "immediate causes",
-            basic_causes: 'basic causes',
-            remedial_actions: "remedial actions",
-            prevention: "prevention",
-            risk_rank: 10,
-            resulted_in: ['injury', 'burn'],
-            substandard_acts: ['injury', 'burn'],
-            substandard_conditions: ['injury', 'burn'],
-            energy_transfer_causes: ['injury', 'burn'],
-            personal_factors: ['injury', 'burn'],
-            job_factors: ['injury', 'burn'],
-        );
-
-        $event->setMetaData(['user_id' => $supervisor->id]);
-
-        $event->handle();
-
-        $incident->refresh();
-
-        $this->assertEquals(InReview::class, $incident->status::class);
-    }
-
     public function test_sends_received_notification_to_admin()
     {
         Notification::fake();


### PR DESCRIPTION
# Feature Addition [CLOSES #190]

## Summary

Adds a new route for supervisors to request a review of there investigation and root cause analysis.

## Rationale

Previously transitioned to in review on investigation submitted, then RCA was introduced and in review needed to happen after both not just one.

## Design Documentation

N/A

## Changes

- Incident review requested event added, transitions state from assigned to in review and adds comment saying review was requested, sends notification to entire admin team.
- Incident policy updated with requestReview
  - requires the user to have correct permission
  - to be the assigned user(supervisor) of the given incident
  - the incident to be in the assigned state
  - the most recent investigation and most recent RCA must be owned by the assigned user(supervisor)
- New frontend button added to make request to new route

## Impact

N/A

## Testing

Unit tests added on event policy and aggregate root. Feature tests added on route and controller.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/ea19e457-2c95-474a-ad2b-84b0074e0937)

## Checklist

- [ ] Code follows the project's coding standards

- [ ] Unit tests covering the new feature have been added

- [ ] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

RCA still not showing waiting on RCA show page to be completed.
