### PR TITLE
Fixes supervisors not able to provide follow up on returned incidents

### DIFF
--- a/app/Http/Controllers/Incident/IncidentController.php
+++ b/app/Http/Controllers/Incident/IncidentController.php
@@ -97,7 +97,8 @@ class IncidentController extends Controller
         return Inertia::render('Incident/Show', [
             'incident' => $incident->load(['comments.user', 'supervisor']),
             'supervisors' => $supervisors,
-            'canRequestReview' => $user->can('requestReview', $incident)
+            'canRequestReview' => $user->can('requestReview', $incident),
+            'canProvideFollowup' => $user->can('provideFollowup', $incident),
         ]);
     }
 

--- a/resources/js/Pages/Incident/Partials/ShowComponents/IncidentSupervisorActions.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/IncidentSupervisorActions.tsx
@@ -8,9 +8,14 @@ import dateTimeFormat from '@/Filters/dateTimeFormat';
 interface SupervisorActionsProps {
     incident: Incident;
     canRequestReview: boolean;
+    canProvideFollowup: boolean;
 }
 
-export default function IncidentSupervisorActions({ incident, canRequestReview }: SupervisorActionsProps) {
+export default function IncidentSupervisorActions({
+    incident,
+    canRequestReview,
+    canProvideFollowup,
+}: SupervisorActionsProps) {
     return (
         <div className="lg:col-start-3 lg:row-end-1 bg-white rounded-lg">
             <div className="rounded-lg  shadow-sm ring-1 ring-gray-900/5">
@@ -41,7 +46,7 @@ export default function IncidentSupervisorActions({ incident, canRequestReview }
                     )}
 
                     {incident.root_cause_analyses.length > 0 && (
-                        <div className="flex flex-col gap-y-6 w-full mt-6 px-6">
+                        <div className="flex flex-col gap-y-6 w-full mt-6 px-6 pb-6 ">
                             <div className="font-semibold">
                                 Root Cause Analyses
                                 {incident.root_cause_analyses.map((rca) => (
@@ -61,26 +66,30 @@ export default function IncidentSupervisorActions({ incident, canRequestReview }
                         </div>
                     )}
 
-                    {incident.status === IncidentStatus.ASSIGNED && (
+                    {(canProvideFollowup || canRequestReview) && (
                         <div className="flex flex-col gap-y-6 w-full mt-6 border-t border-gray-900/5 p-6">
-                            <Link
-                                href={route('incidents.investigations.create', {
-                                    incident: incident.id,
-                                })}
-                                as="button"
-                                className="text-center rounded-md bg-upei-green-500 px-3 py-2  text-sm font-semibold text-white shadow-sm hover:bg-upei-green-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-upei-green-600"
-                            >
-                                Submit Investigation
-                            </Link>
-                            <Link
-                                href={route('incidents.root-cause-analyses.create', {
-                                    incident: incident.id,
-                                })}
-                                as="button"
-                                className="text-center rounded-md bg-upei-green-500 px-3 py-2  text-sm font-semibold text-white shadow-sm hover:bg-upei-green-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-upei-green-600"
-                            >
-                                Submit Root Cause Analysis
-                            </Link>
+                            {canProvideFollowup && (
+                                <>
+                                    <Link
+                                        href={route('incidents.investigations.create', {
+                                            incident: incident.id,
+                                        })}
+                                        as="button"
+                                        className="text-center rounded-md bg-upei-green-500 px-3 py-2  text-sm font-semibold text-white shadow-sm hover:bg-upei-green-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-upei-green-600"
+                                    >
+                                        Submit Investigation
+                                    </Link>
+                                    <Link
+                                        href={route('incidents.root-cause-analyses.create', {
+                                            incident: incident.id,
+                                        })}
+                                        as="button"
+                                        className="text-center rounded-md bg-upei-green-500 px-3 py-2  text-sm font-semibold text-white shadow-sm hover:bg-upei-green-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-upei-green-600"
+                                    >
+                                        Submit Root Cause Analysis
+                                    </Link>
+                                </>
+                            )}
                             {canRequestReview && (
                                 <Link
                                     href={route('incidents.request-review', {

--- a/tests/Feature/Incident/AddCommentTest.php
+++ b/tests/Feature/Incident/AddCommentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Incident;
+namespace Tests\Feature\Incident;
 
 use App\Data\CommentData;
 use App\Enum\CommentType;

--- a/tests/Feature/Incident/SearchTest.php
+++ b/tests/Feature/Incident/SearchTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature\Incident;
+namespace Tests\Feature\Incident;
 
 use App\Models\Incident;
 use App\Models\User;

--- a/tests/Feature/Investigation/StoreTest.php
+++ b/tests/Feature/Investigation/StoreTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Investigation;
+namespace Tests\Feature\Investigation;
 
 use App\Data\InvestigationData;
 use App\Enum\CommentType;

--- a/tests/Feature/Report/ReportDataTest.php
+++ b/tests/Feature/Report/ReportDataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Report;
+namespace Tests\Feature\Report;
 
 use App\Models\Incident;
 use App\Models\User;

--- a/tests/Feature/RootCauseAnalysis/StoreTest.php
+++ b/tests/Feature/RootCauseAnalysis/StoreTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RootCauseAnalysis;
+namespace Tests\Feature\RootCauseAnalysis;
 
 use App\Data\RootCauseAnalysisData;
 use App\Enum\CommentType;

--- a/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
+++ b/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Aggregates;
+namespace Tests\Unit\Aggregates;
 
 use App\Aggregates\InvestigationAggregateRoot;
 use App\Data\InvestigationData;

--- a/tests/Unit/Aggregates/RootCauseAnalysisAggregateRootTest.php
+++ b/tests/Unit/Aggregates/RootCauseAnalysisAggregateRootTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Aggregates;
+namespace Tests\Unit\Aggregates;
 
 use App\Aggregates\RootCauseAnalysisAggregateRoot;
 use App\Data\RootCauseAnalysisData;

--- a/tests/Unit/Data/CommentDataTest.php
+++ b/tests/Unit/Data/CommentDataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Data;
+namespace Tests\Unit\Data;
 
 use App\Data\CommentData;
 use Illuminate\Validation\ValidationException;

--- a/tests/Unit/Data/RootCauseAnalysisDataTest.php
+++ b/tests/Unit/Data/RootCauseAnalysisDataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Data;
+namespace Tests\Unit\Data;
 
 use App\Data\RootCauseAnalysisData;
 use Illuminate\Validation\ValidationException;

--- a/tests/Unit/Models/CommentTest.php
+++ b/tests/Unit/Models/CommentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Models;
+namespace Tests\Unit\Models;
 
 use App\Enum\CommentType;
 use App\Models\Comment;

--- a/tests/Unit/Models/RootCauseAnalysisTest.php
+++ b/tests/Unit/Models/RootCauseAnalysisTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Models;
+namespace Tests\Unit\Models;
 
 use App\Models\Incident;
 use App\Models\RootCauseAnalysis;

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Models;
+namespace Tests\Unit\Models;
 
 use App\Models\User;
 use Tests\TestCase;

--- a/tests/Unit/Policies/IncidentPolicyTest.php
+++ b/tests/Unit/Policies/IncidentPolicyTest.php
@@ -8,10 +8,145 @@ use App\Models\RootCauseAnalysis;
 use App\Models\User;
 use App\Policies\IncidentPolicy;
 use App\States\IncidentStatus\Assigned;
+use App\States\IncidentStatus\Closed;
+use App\States\IncidentStatus\InReview;
+use App\States\IncidentStatus\Opened;
+use App\States\IncidentStatus\Reopened;
+use App\States\IncidentStatus\Returned;
 use Tests\TestCase;
 
 class IncidentPolicyTest extends TestCase
 {
+    public function test_user_can_not_provide_follow_up_on_assigned_incident()
+    {
+        $user = User::factory()->create()->syncRoles('user');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $user->id,
+            'status' => Assigned::class
+        ]);
+
+        $result = $this->getPolicy()->provideFollowUp($user, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_user_can_not_provide_follow_up_on_returned_incident()
+    {
+        $user = User::factory()->create()->syncRoles('user');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $user->id,
+            'status' => Returned::class
+        ]);
+
+        $result = $this->getPolicy()->provideFollowUp($user, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_admin_can_not_provide_follow_up_on_assigned_incident()
+    {
+        $admin = User::factory()->create()->syncRoles('admin');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $admin->id,
+            'status' => Assigned::class
+        ]);
+
+        $result = $this->getPolicy()->provideFollowUp($admin, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_admin_can_not_provide_follow_up_on_returned_incident()
+    {
+        $admin = User::factory()->create()->syncRoles('admin');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $admin->id,
+            'status' => Returned::class
+        ]);
+
+        $result = $this->getPolicy()->provideFollowUp($admin, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_can_not_provide_follow_up_on_closed_incident()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Closed::class
+        ]);
+
+        $result = $this->getPolicy()->provideFollowUp($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_can_not_provide_follow_up_on_reopened_incident()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Reopened::class
+        ]);
+
+        $result = $this->getPolicy()->provideFollowUp($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_can_not_provide_follow_up_on_in_review_incident()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => InReview::class
+        ]);
+
+        $result = $this->getPolicy()->provideFollowUp($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_can_not_provide_follow_up_on_open_incident()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Opened::class
+        ]);
+
+        $result = $this->getPolicy()->provideFollowUp($supervisor, $incident);
+
+        $this->assertFalse($result);
+    }
+
+    public function test_supervisor_can_provide_follow_up_on_returned_incident()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Returned::class
+        ]);
+
+        $result = $this->getPolicy()->provideFollowUp($supervisor, $incident);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_supervisor_can_provide_follow_up_on_assigned_incident()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Assigned::class
+        ]);
+
+        $result = $this->getPolicy()->provideFollowUp($supervisor, $incident);
+
+        $this->assertTrue($result);
+    }
+
     public function test_supervisor_can_request_review()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
@@ -21,12 +156,12 @@ class IncidentPolicyTest extends TestCase
             'status' => Assigned::class
         ]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
 
-        $rca = RootCauseAnalysis::factory()->create([
+        RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
@@ -44,12 +179,12 @@ class IncidentPolicyTest extends TestCase
             'status' => Assigned::class
         ]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
 
-        $rca = RootCauseAnalysis::factory()->create([
+        RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
@@ -67,12 +202,12 @@ class IncidentPolicyTest extends TestCase
             'supervisor_id' => $supervisor->id,
         ]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
 
-        $rca = RootCauseAnalysis::factory()->create([
+        RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
@@ -91,11 +226,11 @@ class IncidentPolicyTest extends TestCase
             'status' => Assigned::class
         ]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
         ]);
 
-        $rca = RootCauseAnalysis::factory()->create([
+        RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,
         ]);
 
@@ -113,12 +248,12 @@ class IncidentPolicyTest extends TestCase
             'status' => Assigned::class
         ]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
 
-        $rca = RootCauseAnalysis::factory()->create([
+        RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,
         ]);
 
@@ -136,11 +271,11 @@ class IncidentPolicyTest extends TestCase
             'status' => Assigned::class
         ]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
         ]);
 
-        $rca = RootCauseAnalysis::factory()->create([
+        RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
@@ -173,7 +308,7 @@ class IncidentPolicyTest extends TestCase
             'status' => Assigned::class
         ]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
@@ -192,7 +327,7 @@ class IncidentPolicyTest extends TestCase
             'status' => Assigned::class
         ]);
 
-        $rca = RootCauseAnalysis::factory()->create([
+        RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
@@ -213,12 +348,12 @@ class IncidentPolicyTest extends TestCase
             'status' => Assigned::class
         ]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
 
-        $rca = RootCauseAnalysis::factory()->create([
+        RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
@@ -239,12 +374,12 @@ class IncidentPolicyTest extends TestCase
             'status' => Assigned::class
         ]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
 
-        $rca = RootCauseAnalysis::factory()->create([
+        RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);

--- a/tests/Unit/Policies/InvestigationPolicyTest.php
+++ b/tests/Unit/Policies/InvestigationPolicyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Policies;
+namespace Tests\Unit\Policies;
 
 use App\Models\Incident;
 use App\Models\Investigation;

--- a/tests/Unit/Policies/ReportPolicyTest.php
+++ b/tests/Unit/Policies/ReportPolicyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Policies;
+namespace Tests\Unit\Policies;
 
 use App\Models\User;
 use App\Policies\ReportPolicy;

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Policies;
+namespace Tests\Unit\Policies;
 
 use App\Models\User;
 use App\Policies\UserPolicy;

--- a/tests/Unit/Projectors/StoredEventProjectorTest.php
+++ b/tests/Unit/Projectors/StoredEventProjectorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Projectors;
+namespace Tests\Unit\Projectors;
 
 use App\Projectors\StoredEventProjector;
 use App\StorableEvents\StoredEvent;

--- a/tests/Unit/Reactors/StoredEventReactorTest.php
+++ b/tests/Unit/Reactors/StoredEventReactorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Reactors;
+namespace Tests\Unit\Reactors;
 
 use App\Reactors\StoredEventReactor;
 use App\StorableEvents\StoredEvent;

--- a/tests/Unit/States/IncidentStatusStateTest.php
+++ b/tests/Unit/States/IncidentStatusStateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace States;
+namespace Tests\Unit\States;
 
 use App\Models\Incident;
 use App\States\IncidentStatus\Assigned;

--- a/tests/Unit/StoreableEvents/Comment/CommentCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Comment/CommentCreatedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StoreableEvents\Comment;
+namespace Tests\Unit\StoreableEvents\Comment;
 
 use App\Enum\CommentType;
 use App\Models\Comment;

--- a/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StoreableEvents\Incident;
+namespace Tests\Unit\StoreableEvents\Incident;
 
 use App\Enum\CommentType;
 use App\Enum\IncidentType;

--- a/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StoreableEvents\Incident;
+namespace Tests\Unit\StoreableEvents\Incident;
 
 use App\Enum\CommentType;
 use App\Models\Incident;

--- a/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StoreableEvents\Investigation;
+namespace Tests\Unit\StoreableEvents\Investigation;
 
 use App\Enum\CommentType;
 use App\Models\Incident;

--- a/tests/Unit/StoreableEvents/RootCauseAnalysis/RootCauseAnalysisCreatedTest.php
+++ b/tests/Unit/StoreableEvents/RootCauseAnalysis/RootCauseAnalysisCreatedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StoreableEvents\RootCauseAnalysis;
+namespace Tests\Unit\StoreableEvents\RootCauseAnalysis;
 
 use App\Enum\CommentType;
 use App\Models\Incident;

--- a/tests/Unit/StoreableEvents/User/UserCreatedTest.php
+++ b/tests/Unit/StoreableEvents/User/UserCreatedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StoreableEvents\User;
+namespace Tests\Unit\StoreableEvents\User;
 
 use App\Enum\RolesEnum;
 use App\Mail\UserAdded;

--- a/tests/Unit/StoreableEvents/User/UserDeletedTest.php
+++ b/tests/Unit/StoreableEvents/User/UserDeletedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StoreableEvents\User;
+namespace Tests\Unit\StoreableEvents\User;
 
 use App\Models\User;
 use App\StorableEvents\User\UserDeleted;

--- a/tests/Unit/StoreableEvents/User/UserRoleUpdatedTest.php
+++ b/tests/Unit/StoreableEvents/User/UserRoleUpdatedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace StoreableEvents\User;
+namespace Tests\Unit\StoreableEvents\User;
 
 use App\Enum\RolesEnum;
 use App\Models\User;


### PR DESCRIPTION
# Bug Fix

## Summary

Fixes supervisors not able to provide follow up on returned incidents

## Issue Link

FIXES #211 

## Root Cause Analysis

Follow up buttons were being conditionally rendered based only on assigned status.

## Changes

- Updated Incident policy to check if a user is authorized to provide incident follow up
- Updated incident controller to pass result of this policy as canProvideFollowup prop to Incidents/Show page
- Updated Incidents/Show page to conditionally render follow up buttons based canProvideFollowup
- Updated all tests to have correct name space.

## Impact

NA

## Testing Strategy

- Updated IncidentPolicyTest
- Updated Incident/Show feature test

## Regression Risk

NA

## Checklist

- [x] The fix has been locally tested

- [x] New unit tests have been added to prevent future regressions

- [x] The documentation has been updated if necessary

## Additional Notes

NA