### PR TITLE
Null user_id on event comments

### DIFF
--- a/app/StorableEvents/Comment/CommentCreated.php
+++ b/app/StorableEvents/Comment/CommentCreated.php
@@ -20,7 +20,7 @@ class CommentCreated extends StoredEvent
     {
         $comment = new Comment;
 
-        $comment->user_id = $this->metaData['user_id'] ?? null;
+        $comment->user_id = $this->metaData['user_id'];
         $comment->content = $this->content;
         $comment->type = $this->type;
 

--- a/app/StorableEvents/Incident/IncidentClosed.php
+++ b/app/StorableEvents/Incident/IncidentClosed.php
@@ -18,7 +18,7 @@ class IncidentClosed extends StoredEvent
 
         $comment = new Comment;
 
-        $comment->user_id = $this->metaData['user_id'] ?? null;
+        $comment->user_id = $this->metaData['user_id'];
         $comment->type = CommentType::ACTION;
         $comment->content = 'Incident was closed.';
 

--- a/app/StorableEvents/Incident/IncidentReopened.php
+++ b/app/StorableEvents/Incident/IncidentReopened.php
@@ -19,7 +19,7 @@ class IncidentReopened extends StoredEvent
 
         $comment = new Comment;
 
-        $comment->user_id = $this->metaData['user_id'] ?? null;
+        $comment->user_id = $this->metaData['user_id'];
         $comment->type = CommentType::ACTION;
         $comment->content = 'Incident was reopened.';
 

--- a/app/StorableEvents/Incident/SupervisorAssigned.php
+++ b/app/StorableEvents/Incident/SupervisorAssigned.php
@@ -32,7 +32,7 @@ class SupervisorAssigned extends StoredEvent
 
         $comment = new Comment;
 
-        $comment->user_id = $this->metaData['user_id'] ?? null;
+        $comment->user_id = $this->metaData['user_id'];
         $comment->type = CommentType::ACTION;
         $comment->content = 'Incident was assigned to supervisor: ' . $this->supervisor()->name;
 

--- a/app/StorableEvents/Incident/SupervisorUnassigned.php
+++ b/app/StorableEvents/Incident/SupervisorUnassigned.php
@@ -19,7 +19,7 @@ class SupervisorUnassigned extends StoredEvent
 
         $comment = new Comment;
 
-        $comment->user_id = $this->metaData['user_id'] ?? null;
+        $comment->user_id = $this->metaData['user_id'];
         $comment->type = CommentType::ACTION;
         $comment->content = 'Incident was unassigned.';
 

--- a/app/StorableEvents/Investigation/InvestigationReturned.php
+++ b/app/StorableEvents/Investigation/InvestigationReturned.php
@@ -24,7 +24,7 @@ class InvestigationReturned extends StoredEvent
 
         $comment = new Comment;
 
-        $comment->user_id = $this->metaData['user_id'] ?? null;
+        $comment->user_id = $this->metaData['user_id'];
         $comment->type = CommentType::ACTION;
         $comment->content = 'Incident was returned for re-investigation.';
 

--- a/app/StorableEvents/RootCauseAnalysis/RootCauseAnalysisReturned.php
+++ b/app/StorableEvents/RootCauseAnalysis/RootCauseAnalysisReturned.php
@@ -20,7 +20,7 @@ class RootCauseAnalysisReturned extends StoredEvent
 
         $comment = new Comment;
 
-        $comment->user_id = $this->metaData['user_id'] ?? null;
+        $comment->user_id = $this->metaData['user_id'];
         $comment->type = CommentType::ACTION;
         $comment->content = 'Incident Root Cause Analysis was returned for re-review.';
 

--- a/tests/Unit/StoreableEvents/Incident/IncidentClosedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentClosedTest.php
@@ -23,6 +23,7 @@ class IncidentClosedTest extends TestCase
 
         $event = new IncidentClosed;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
 
         $incident->refresh();
@@ -47,6 +48,7 @@ class IncidentClosedTest extends TestCase
 
         $event = new IncidentClosed;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
 
         $incident->refresh();

--- a/tests/Unit/StoreableEvents/Incident/IncidentReopenedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReopenedTest.php
@@ -27,6 +27,7 @@ class IncidentReopenedTest extends TestCase
 
         $event = new IncidentReopened;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
     }
 
@@ -41,6 +42,7 @@ class IncidentReopenedTest extends TestCase
 
         $event = new IncidentReopened;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
 
         $incident->refresh();
@@ -65,6 +67,7 @@ class IncidentReopenedTest extends TestCase
 
         $event = new IncidentReopened;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
 
         $incident->refresh();

--- a/tests/Unit/StoreableEvents/Incident/SupervisorAssignedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/SupervisorAssignedTest.php
@@ -19,6 +19,7 @@ class SupervisorAssignedTest extends TestCase
 
         $event = new SupervisorAssigned($supervisor->id);
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
 
         $this->assertDatabaseCount('comments', 0);
 
@@ -43,10 +44,12 @@ class SupervisorAssignedTest extends TestCase
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
         $incident = Incident::factory()->create();
+
         $this->assertEquals(Opened::class, $incident->status::class);
 
         $event = new SupervisorAssigned($supervisor->id);
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
 
         $incident->refresh();
@@ -59,6 +62,7 @@ class SupervisorAssignedTest extends TestCase
 
         $event = new SupervisorAssigned($supervisor->id);
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
 
         $incident->refresh();

--- a/tests/Unit/StoreableEvents/Incident/SupervisorUnassignedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/SupervisorUnassignedTest.php
@@ -23,6 +23,7 @@ class SupervisorUnassignedTest extends TestCase
         $event = new SupervisorUnassigned;
 
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
 
         $incident->refresh();
@@ -46,6 +47,7 @@ class SupervisorUnassignedTest extends TestCase
         $event = new SupervisorUnassigned;
 
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
 
         $incident->refresh();

--- a/tests/Unit/StoreableEvents/Investigation/InvestigationReturnedTest.php
+++ b/tests/Unit/StoreableEvents/Investigation/InvestigationReturnedTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\StoreableEvents\Investigation;
 
 use App\Enum\CommentType;
 use App\Models\Incident;
+use App\Models\User;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\InReview;
 use App\States\IncidentStatus\Returned;
@@ -17,23 +18,29 @@ class InvestigationReturnedTest extends TestCase
     {
         $this->expectException(TransitionNotFound::class);
 
+        $admin = User::factory()->create();
+
         $incident = Incident::factory()->create([
             'status' => Assigned::class,
         ]);
 
         $event = new InvestigationReturned;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $admin->id]);
         $event->handle();
     }
 
     public function test_returning_investigation_adds_returned_comment()
     {
+        $admin = User::factory()->create();
+
         $incident = Incident::factory()->create([
             'status' => InReview::class,
         ]);
 
         $event = new InvestigationReturned;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $admin->id]);
         $event->handle();
 
         $incident->refresh();
@@ -49,12 +56,15 @@ class InvestigationReturnedTest extends TestCase
 
     public function test_returns_incident_investigation()
     {
+        $admin = User::factory()->create();
+
         $incident = Incident::factory()->create([
             'status' => InReview::class,
         ]);
 
         $event = new InvestigationReturned;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $admin->id]);
         $event->handle();
 
         $incident->refresh();

--- a/tests/Unit/StoreableEvents/RootCauseAnalysis/RootCauseAnalysisReturnedTest.php
+++ b/tests/Unit/StoreableEvents/RootCauseAnalysis/RootCauseAnalysisReturnedTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\StoreableEvents\RootCauseAnalysis;
 
 use App\Enum\CommentType;
 use App\Models\Incident;
+use App\Models\User;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\InReview;
 use App\States\IncidentStatus\Returned;
@@ -17,23 +18,29 @@ class RootCauseAnalysisReturnedTest extends TestCase
     {
         $this->expectException(TransitionNotFound::class);
 
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
         $incident = Incident::factory()->create([
             'status' => Assigned::class,
         ]);
 
         $event = new RootCauseAnalysisReturned;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
     }
 
     public function test_returning_rca_adds_returned_comment()
     {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
         $incident = Incident::factory()->create([
             'status' => InReview::class,
         ]);
 
         $event = new RootCauseAnalysisReturned;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
 
         $incident->refresh();
@@ -49,12 +56,15 @@ class RootCauseAnalysisReturnedTest extends TestCase
 
     public function test_returns_incident_rca()
     {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
         $incident = Incident::factory()->create([
             'status' => InReview::class,
         ]);
 
         $event = new RootCauseAnalysisReturned;
         $event->setAggregateRootUuid($incident->id);
+        $event->setMetaData([...$event->metaData(), 'user_id' => $supervisor->id]);
         $event->handle();
 
         $incident->refresh();


### PR DESCRIPTION
# Bug Fix

## Summary

Removes null coalesce on comment user id from metadata. The only comment which will never have a user attached is the incident created event comment.

## Issue Link

FIXES #207 

## Root Cause Analysis

N/A

## Changes

- Events which should have a user attached expect a user_id key to be present in the meta. Tests have been updated to accommodate.

## Impact

New events that are made and have comments will need to be written and tested in the same way as what is done here.

## Testing Strategy

Existing tests were in place and have been updated.

## Regression Risk

Future events and tests will need to not have null coalesce checks.

## Checklist

- [ ] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes

N/A
