### PR TITLE
Fixes notification pagination bug

### DIFF
--- a/resources/js/Layouts/Partials/NotificationComponents/NotificationActions.tsx
+++ b/resources/js/Layouts/Partials/NotificationComponents/NotificationActions.tsx
@@ -10,7 +10,11 @@ export default function NotificationActions() {
         try {
             router.delete(route('notifications.destroy-all'), {
                 onSuccess: () =>
-                    router.reload({ only: ['notifications, notifications_paginator'] }),
+                    router.reload({
+                        only: ['notifications', 'notifications_paginator'],
+                        reset: ['notifications', 'notifications_paginator'],
+                        data: { notifications: 1 },
+                    }),
             });
         } catch (error) {
             console.error(error);
@@ -22,8 +26,9 @@ export default function NotificationActions() {
             router.put(route('notifications.mark-all-read'), undefined, {
                 onSuccess: () =>
                     router.reload({
-                        only: ['notifications, notifications_paginator'],
-                        reset: ['notifications'],
+                        only: ['notifications', 'notifications_paginator'],
+                        reset: ['notifications', 'notifications_paginator'],
+                        data: { notifications: 1 },
                     }),
             });
         } catch (error) {

--- a/resources/js/Layouts/Partials/NotificationComponents/NotificationList.tsx
+++ b/resources/js/Layouts/Partials/NotificationComponents/NotificationList.tsx
@@ -13,8 +13,9 @@ export default function NotificationList({ notifications, title }: NotificationL
             router.delete(route('notifications.destroy', { notification: id }), {
                 onSuccess: () =>
                     router.reload({
-                        only: ['notifications, notifications_paginator'],
-                        reset: ['notifications'],
+                        only: ['notifications', 'notifications_paginator'],
+                        reset: ['notifications', 'notifications_paginator'],
+                        data: { notifications: 1 },
                     }),
             });
         } catch (error) {
@@ -40,6 +41,7 @@ export default function NotificationList({ notifications, title }: NotificationL
                             <div className="w-full px-2">
                                 <p className="text-sm/6 font-semibold text-gray-900">
                                     {notification.data.message}
+                                    <div>{notification.id}</div>
                                 </p>
                                 <p className="mt-1 truncate text-xs/5 text-gray-500">
                                     {timeSince(notification.created_at)}

--- a/resources/js/Layouts/Partials/Notifications.tsx
+++ b/resources/js/Layouts/Partials/Notifications.tsx
@@ -41,7 +41,9 @@ export default function Notifications() {
                                 notifications_paginator.last_page && (
                                 <WhenVisible
                                     always
-                                    fallback={<LoadingIndicator />}
+                                    fallback={
+                                        <LoadingIndicator className="w-full text-center my-2" />
+                                    }
                                     params={{
                                         data: {
                                             notifications: notifications_paginator.current_page + 1,


### PR DESCRIPTION
# Bug Fix

## Summary

Marking all notifications as read breaks pagination

## Issue Link

FIXES #222 

## Root Cause Analysis

Pagination not reset after updating state of notifications

## Changes

Resets pagination and sets current page to one when any update is made to notifications 

## Impact

NA

## Testing Strategy

Same steps outlined in #222 

## Regression Risk
NA

## Checklist

- [x] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [x] The documentation has been updated if necessary

## Additional Notes

NA