### PR TITLE
Adds InvestigationReturnedNotification

### DIFF
--- a/app/Notifications/BaseNotification.php
+++ b/app/Notifications/BaseNotification.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+abstract class BaseNotification extends Notification
+{
+    use Queueable;
+
+    public string $message;
+    public string $url;
+
+}

--- a/app/Notifications/Incident/IncidentReviewRequestNotification.php
+++ b/app/Notifications/Incident/IncidentReviewRequestNotification.php
@@ -1,33 +1,23 @@
 <?php
 
-namespace App\Notifications\Investigation;
+namespace App\Notifications\Incident;
 
 use App\Models\User;
-use Illuminate\Bus\Queueable;
+use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\VonageMessage;
-use Illuminate\Notifications\Notification;
 
-class InvestigationSubmitted extends Notification
+class IncidentReviewRequestNotification extends BaseNotification
 {
-    use Queueable;
-
-    public string $message;
-    public string $url;
-
     /**
      * Create a new notification instance.
      */
     public function __construct(
         public string $incidentId,
-        public string $investigationId,
         public User $supervisor,
     ) {
-        $this->message = "A new investigation was submitted by {$this->supervisor->name}";
-        $this->url = route('incidents.investigations.show', [
-            'incident' => $this->incidentId,
-            'investigation' => $this->investigationId
-        ]);
+        $this->message = "{$this->supervisor->name} has requested an incident follow up review.";
+        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
     }
 
     /**
@@ -46,8 +36,8 @@ class InvestigationSubmitted extends Notification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Investigation Submitted')
-            ->markdown('mail.investigation-submitted', ['url' => $this->url]);
+            ->subject('Incident Follow Up Review Request')
+            ->markdown('mail.incident-review-request', ['url' => $this->url]);
     }
 
     /**
@@ -69,7 +59,6 @@ class InvestigationSubmitted extends Notification
         return [
             'url' => $this->url,
             'message' => $this->message,
-            'supervisor_name' => $this->supervisor->name,
         ];
     }
 }

--- a/app/Notifications/Incident/IncidentSubmittedNotification.php
+++ b/app/Notifications/Incident/IncidentSubmittedNotification.php
@@ -2,19 +2,12 @@
 
 namespace App\Notifications\Incident;
 
-use Illuminate\Bus\Queueable;
+use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\VonageMessage;
-use Illuminate\Notifications\Notification;
 
-class IncidentSubmitted extends Notification
+class IncidentSubmittedNotification extends BaseNotification
 {
-    use Queueable;
-
-    public string $message;
-    public string $url;
-
-
     /**
      * Create a new notification instance.
      */

--- a/app/Notifications/Investigation/InvestigationReturnedNotification.php
+++ b/app/Notifications/Investigation/InvestigationReturnedNotification.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Notifications\Investigation;
+
+use App\Models\User;
+use App\Notifications\BaseNotification;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\VonageMessage;
+
+class InvestigationReturnedNotification extends BaseNotification
+{
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $incidentId,
+        public string $investigationId,
+        public User $admin
+    ) {
+        $this->message = "$admin->name has returned your investigation for further review";
+        $this->url = route('incidents.investigations.show', [
+            'incident' => $this->incidentId,
+            'investigation' => $this->investigationId
+        ]);
+    }
+
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database', 'vonage'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Investigation Returned')
+            ->markdown('mail.investigation-returned', ['url' => $this->url, 'message' => $this->message]);
+    }
+
+    /**
+     * Get the Vonage / SMS representation of the notification.
+     */
+    public function toVonage(object $notifiable): VonageMessage
+    {
+        return (new VonageMessage)
+            ->content($this->message);
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'url' => $this->url,
+            'message' => $this->message,
+        ];
+    }
+
+
+}

--- a/app/Notifications/Investigation/InvestigationSubmittedNotification.php
+++ b/app/Notifications/Investigation/InvestigationSubmittedNotification.php
@@ -1,29 +1,27 @@
 <?php
 
-namespace App\Notifications\Incident;
+namespace App\Notifications\Investigation;
 
 use App\Models\User;
-use Illuminate\Bus\Queueable;
+use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\VonageMessage;
-use Illuminate\Notifications\Notification;
 
-class IncidentReviewRequest extends Notification
+class InvestigationSubmittedNotification extends BaseNotification
 {
-    use Queueable;
-
-    public string $message;
-    public string $url;
-
     /**
      * Create a new notification instance.
      */
     public function __construct(
         public string $incidentId,
+        public string $investigationId,
         public User $supervisor,
     ) {
-        $this->message = "{$this->supervisor->name} has requested an incident follow up review.";
-        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
+        $this->message = "A new investigation was submitted by {$this->supervisor->name}";
+        $this->url = route('incidents.investigations.show', [
+            'incident' => $this->incidentId,
+            'investigation' => $this->investigationId
+        ]);
     }
 
     /**
@@ -42,8 +40,8 @@ class IncidentReviewRequest extends Notification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Incident Follow Up Review Request')
-            ->markdown('mail.incident-review-request', ['url' => $this->url]);
+            ->subject('Investigation Submitted')
+            ->markdown('mail.investigation-submitted', ['url' => $this->url]);
     }
 
     /**
@@ -65,6 +63,7 @@ class IncidentReviewRequest extends Notification
         return [
             'url' => $this->url,
             'message' => $this->message,
+            'supervisor_name' => $this->supervisor->name,
         ];
     }
 }

--- a/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
+++ b/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
@@ -3,18 +3,12 @@
 namespace App\Notifications\RootCauseAnalysis;
 
 use App\Models\User;
-use Illuminate\Bus\Queueable;
+use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\VonageMessage;
-use Illuminate\Notifications\Notification;
 
-class RootCauseAnalysisSubmitted extends Notification
+class RootCauseAnalysisSubmittedNotification extends BaseNotification
 {
-    use Queueable;
-
-    public string $message;
-    public string $url;
-
     /**
      * Create a new notification instance.
      */

--- a/app/StorableEvents/Incident/IncidentCreated.php
+++ b/app/StorableEvents/Incident/IncidentCreated.php
@@ -8,7 +8,7 @@ use App\Mail\IncidentReceived;
 use App\Models\Comment;
 use App\Models\Incident;
 use App\Models\User;
-use App\Notifications\Incident\IncidentSubmitted;
+use App\Notifications\Incident\IncidentSubmittedNotification;
 use App\StorableEvents\StoredEvent;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Mail;
@@ -92,6 +92,6 @@ class IncidentCreated extends StoredEvent
         }
 
         $admins = User::role('admin')->get();
-        Notification::send($admins, new IncidentSubmitted($this->aggregateRootUuid(), $this->first_name, $this->last_name));
+        Notification::send($admins, new IncidentSubmittedNotification($this->aggregateRootUuid(), $this->first_name, $this->last_name));
     }
 }

--- a/app/StorableEvents/Incident/IncidentReviewRequested.php
+++ b/app/StorableEvents/Incident/IncidentReviewRequested.php
@@ -6,7 +6,7 @@ use App\Enum\CommentType;
 use App\Models\Comment;
 use App\Models\Incident;
 use App\Models\User;
-use App\Notifications\Incident\IncidentReviewRequest;
+use App\Notifications\Incident\IncidentReviewRequestNotification;
 use App\States\IncidentStatus\InReview;
 use App\StorableEvents\StoredEvent;
 use Illuminate\Support\Facades\Notification;
@@ -42,6 +42,6 @@ class IncidentReviewRequested extends StoredEvent
 
         $supervisor = User::find($this->metaData['user_id']);
 
-        Notification::send($admins, new IncidentReviewRequest($this->aggregateRootUuid(), $supervisor));
+        Notification::send($admins, new IncidentReviewRequestNotification($this->aggregateRootUuid(), $supervisor));
     }
 }

--- a/app/StorableEvents/Investigation/InvestigationCreated.php
+++ b/app/StorableEvents/Investigation/InvestigationCreated.php
@@ -7,7 +7,7 @@ use App\Models\Comment;
 use App\Models\Incident;
 use App\Models\Investigation;
 use App\Models\User;
-use App\Notifications\Investigation\InvestigationSubmitted;
+use App\Notifications\Investigation\InvestigationSubmittedNotification;
 use App\StorableEvents\StoredEvent;
 use Illuminate\Support\Facades\Notification;
 
@@ -79,6 +79,6 @@ class InvestigationCreated extends StoredEvent
 
         $supervisor = User::find($this->metaData['user_id']);
 
-        Notification::send($admins, new InvestigationSubmitted($this->incident_id, $this->aggregateRootUuid(), $supervisor));
+        Notification::send($admins, new InvestigationSubmittedNotification($this->incident_id, $this->aggregateRootUuid(), $supervisor));
     }
 }

--- a/app/StorableEvents/Investigation/InvestigationReturned.php
+++ b/app/StorableEvents/Investigation/InvestigationReturned.php
@@ -10,7 +10,7 @@ use App\Models\User;
 use App\States\IncidentStatus\Returned;
 use App\StorableEvents\StoredEvent;
 use Illuminate\Support\Facades\Notification;
-use \App\Notifications\Investigation\InvestigationReturnedNotification;
+use App\Notifications\Investigation\InvestigationReturnedNotification;
 
 class InvestigationReturned extends StoredEvent
 {

--- a/app/StorableEvents/Investigation/InvestigationReturned.php
+++ b/app/StorableEvents/Investigation/InvestigationReturned.php
@@ -5,8 +5,12 @@ namespace App\StorableEvents\Investigation;
 use App\Enum\CommentType;
 use App\Models\Comment;
 use App\Models\Incident;
+use App\Models\Investigation;
+use App\Models\User;
 use App\States\IncidentStatus\Returned;
 use App\StorableEvents\StoredEvent;
+use Illuminate\Support\Facades\Notification;
+use \App\Notifications\Investigation\InvestigationReturnedNotification;
 
 class InvestigationReturned extends StoredEvent
 {
@@ -31,5 +35,13 @@ class InvestigationReturned extends StoredEvent
         $comment->commentable()->associate($incident);
 
         $comment->save();
+    }
+
+    public function react()
+    {
+        $admin = User::find($this->metaData['user_id']);
+        $investigation = Investigation::where('incident_id', $this->aggregateRootUuid())->first();
+        $supervisor = $investigation->supervisor;
+        Notification::send($supervisor, new InvestigationReturnedNotification($this->aggregateRootUuid(), $investigation->id, $admin));
     }
 }

--- a/app/StorableEvents/RootCauseAnalysis/RootCauseAnalysisCreated.php
+++ b/app/StorableEvents/RootCauseAnalysis/RootCauseAnalysisCreated.php
@@ -7,7 +7,7 @@ use App\Models\Comment;
 use App\Models\Incident;
 use App\Models\RootCauseAnalysis;
 use App\Models\User;
-use App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmitted;
+use App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmittedNotification;
 use App\StorableEvents\StoredEvent;
 use Illuminate\Support\Facades\Notification;
 
@@ -83,6 +83,6 @@ class RootCauseAnalysisCreated extends StoredEvent
 
         $supervisor = User::find($this->metaData['user_id']);
 
-        Notification::send($admins, new RootCauseAnalysisSubmitted($this->incident_id, $this->aggregateRootUuid(), $supervisor));
+        Notification::send($admins, new RootCauseAnalysisSubmittedNotification($this->incident_id, $this->aggregateRootUuid(), $supervisor));
     }
 }

--- a/resources/views/mail/incident-received.blade.php
+++ b/resources/views/mail/incident-received.blade.php
@@ -1,14 +1,9 @@
 <x-mail::message>
 # Incident Received
 
-Dear,
+We have received your incident and appreciate you taking the time to inform us.
+Our team will review the details and take appropriate action as soon as possible.
 
-We have received your incident report and appreciate you taking the time to inform us. Our team will review the details and take appropriate action as soon as possible.
-
-If you have any additional information or need to provide updates, please reply to this email or contact our support team.
-
-Thank you for your report.
-
-Best regards,
-UPEI Health, Safety, and Environment
+Thanks,<br>
+{{ config('app.name') }}
 </x-mail::message>

--- a/resources/views/mail/investigation-returned.blade.php
+++ b/resources/views/mail/investigation-returned.blade.php
@@ -1,10 +1,10 @@
 <x-mail::message>
-# Incident Submitted
+# Investigation Returned
 
-A new incident has been submitted.
+{!! $message !!}
 
 <x-mail::button :url="$url">
-View Incident
+View Investigation
 </x-mail::button>
 
 Thanks,<br>

--- a/resources/views/mail/user-added.blade.php
+++ b/resources/views/mail/user-added.blade.php
@@ -13,7 +13,6 @@ To sign in follow the steps below:
 Login
 </x-mail::button>
 
-Best regards,
-
-UPEI Health, Safety, and Environment
+Best regards,<br>
+{{ config('app.name') }}
 </x-mail::message>

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,10 +41,10 @@ Route::get('/notification', function () {
         supervisor: $supervisor,
     );
 
-//    return $incidentReceived->render();
+    //    return $incidentReceived->render();
     // return $userAdded->render();
     // return $incidentSubmitted->toMail($supervisor);
-//     return $investigationSubmitted->toMail($supervisor);
+    //     return $investigationSubmitted->toMail($supervisor);
     return $investigationReturned->toMail();
     // return $rcaSubmitted->toMail($supervisor);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use Inertia\Inertia;
 
 // TODO: Remove, used for demo purposes
 Route::get('/notification', function () {
+    $admin = \App\Models\User::factory()->create()->syncRoles('admin');
     $supervisor = \App\Models\User::factory()->create()->syncRoles('supervisor');
     $incident = \App\Models\Incident::factory()->create();
     $investigation = \App\Models\Investigation::factory()->create();
@@ -16,28 +17,35 @@ Route::get('/notification', function () {
     $incidentReceived = new \App\Mail\IncidentReceived;
     $userAdded = new \App\Mail\UserAdded;
 
-    $incidentSubmitted = new \App\Notifications\Incident\IncidentSubmitted(
+    $incidentSubmitted = new \App\Notifications\Incident\IncidentSubmittedNotification(
         incidentId: $incident->id,
         firstName: null,
         lastName: null,
     );
 
-    $investigationSubmitted = new \App\Notifications\Investigation\InvestigationSubmitted(
+    $investigationSubmitted = new \App\Notifications\Investigation\InvestigationSubmittedNotification(
         incidentId: $incident->id,
         investigationId: $investigation->id,
         supervisor: $supervisor,
     );
 
-    $rcaSubmitted = new \App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmitted(
+    $investigationReturned = new \App\Notifications\Investigation\InvestigationReturnedNotification(
+        incidentId: $incident->id,
+        investigationId: $investigation->id,
+        admin: $admin
+    );
+
+    $rcaSubmitted = new \App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmittedNotification(
         incidentId: $incident->id,
         rootCauseAnalysisId: $rca->id,
         supervisor: $supervisor,
     );
 
-    return $incidentReceived->render();
+//    return $incidentReceived->render();
     // return $userAdded->render();
     // return $incidentSubmitted->toMail($supervisor);
-    // return $investigationSubmitted->toMail($supervisor);
+//     return $investigationSubmitted->toMail($supervisor);
+    return $investigationReturned->toMail();
     // return $rcaSubmitted->toMail($supervisor);
 
 });

--- a/tests/Feature/Incident/StatusTest.php
+++ b/tests/Feature/Incident/StatusTest.php
@@ -7,7 +7,8 @@ use App\Models\Incident;
 use App\Models\Investigation;
 use App\Models\RootCauseAnalysis;
 use App\Models\User;
-use App\Notifications\Incident\IncidentReviewRequest;
+use App\Notifications\Incident\IncidentReviewRequestNotification;
+use App\Notifications\Investigation\InvestigationReturnedNotification;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\Closed;
 use App\States\IncidentStatus\InReview;
@@ -18,6 +19,97 @@ use Tests\TestCase;
 
 class StatusTest extends TestCase
 {
+    public function test_return_investigation_stores_notification_in_database()
+    {
+        Notification::fake();
+
+        $admin = User::factory()->create()->syncRoles('admin');
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($admin);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => InReview::class
+        ]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        Notification::assertNothingSent();
+
+        $response = $this->patch(route('incidents.return-investigation', ['incident' => $incident]));
+        $response->assertOk();
+
+        $incident->refresh();
+
+        Notification::assertCount(1);
+
+        Notification::assertSentTo(
+            $supervisor,
+            function (InvestigationReturnedNotification $notification, array $channels) use ($incident, $investigation, $supervisor) {
+                $databaseStore = $notification->toArray($supervisor);
+
+                $this->assertEquals(
+                    route('incidents.investigations.show', ['incident' => $incident->id, 'investigation' => $investigation->id]),
+                    $databaseStore['url']
+                );
+
+                return array_key_exists('message', $databaseStore);
+            }
+        );
+    }
+
+    public function test_return_investigation_sends_notification_to_supervisor()
+    {
+        Notification::fake();
+
+        $admin = User::factory()->create()->syncRoles('admin');
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($admin);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => InReview::class
+        ]);
+
+       Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        RootCauseAnalysis::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        Notification::assertNothingSent();
+
+        $response = $this->patch(route('incidents.return-investigation', ['incident' => $incident]));
+        $response->assertRedirect();
+
+        $incident->refresh();
+
+        Notification::assertCount(1);
+
+        Notification::assertSentTo(
+            $supervisor,
+            function (InvestigationReturnedNotification $notification, array $channels) use ($incident, $admin) {
+                return $notification->incidentId === $incident->id && $notification->admin->id === $admin->id;
+            }
+        );
+    }
+
     public function test_supervisor_forbidden_to_request_review_if_not_assigned_to_incident()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');
@@ -293,7 +385,7 @@ class StatusTest extends TestCase
 
         Notification::assertSentTo(
             $admins,
-            function (IncidentReviewRequest $notification, array $channels) use ($incident, $admins, $supervisor) {
+            function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $admins, $supervisor) {
                 $databaseStore = $notification->toArray($admins->first());
 
                 $this->assertEquals(route('incidents.show', $incident->id), $databaseStore['url']);
@@ -336,11 +428,11 @@ class StatusTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, IncidentReviewRequest::class);
+        Notification::assertSentTo($admins, IncidentReviewRequestNotification::class);
 
         Notification::assertSentTo(
             $admins,
-            function (IncidentReviewRequest $notification, array $channels) use ($incident, $supervisor) {
+            function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
                 return $notification->incidentId === $incident->id && $notification->supervisor->id === $supervisor->id;
             }
         );

--- a/tests/Feature/Incident/StatusTest.php
+++ b/tests/Feature/Incident/StatusTest.php
@@ -47,7 +47,7 @@ class StatusTest extends TestCase
         Notification::assertNothingSent();
 
         $response = $this->patch(route('incidents.return-investigation', ['incident' => $incident]));
-        $response->assertOk();
+        $response->assertRedirect();
 
         $incident->refresh();
 
@@ -511,6 +511,10 @@ class StatusTest extends TestCase
             'status' => InReview::class,
         ]);
 
+        Investigation::factory()->create([
+            'incident_id' => $incident->id,
+        ]);
+
         $response = $this->patch(route('incidents.return-investigation', ['incident' => $incident]));
 
         $response->assertRedirect();
@@ -619,6 +623,10 @@ class StatusTest extends TestCase
             'status' => InReview::class,
         ]);
 
+        Investigation::factory()->create([
+            'incident_id' => $incident->id,
+        ]);
+
         $response = $this->patch(route('incidents.return-investigation', ['incident' => $incident]));
 
         $response->assertRedirect();
@@ -643,6 +651,10 @@ class StatusTest extends TestCase
 
         $incident = Incident::factory()->create([
             'status' => InReview::class,
+        ]);
+
+        Investigation::factory()->create([
+            'incident_id' => $incident->id,
         ]);
 
         $response = $this->patch(route('incidents.return-investigation', ['incident' => $incident]));

--- a/tests/Feature/Incident/StatusTest.php
+++ b/tests/Feature/Incident/StatusTest.php
@@ -83,10 +83,10 @@ class StatusTest extends TestCase
             'status' => InReview::class
         ]);
 
-       Investigation::factory()->create([
-            'incident_id' => $incident->id,
-            'supervisor_id' => $supervisor->id,
-        ]);
+        Investigation::factory()->create([
+             'incident_id' => $incident->id,
+             'supervisor_id' => $supervisor->id,
+         ]);
 
         RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,

--- a/tests/Feature/Incident/StoreTest.php
+++ b/tests/Feature/Incident/StoreTest.php
@@ -9,7 +9,7 @@ use App\Mail\IncidentReceived;
 use App\Models\CustomStoredEvent;
 use App\Models\Incident;
 use App\Models\User;
-use App\Notifications\Incident\IncidentSubmitted;
+use App\Notifications\Incident\IncidentSubmittedNotification;
 use App\States\IncidentStatus\Opened;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
@@ -486,6 +486,6 @@ class StoreTest extends TestCase
 
         $response = $this->post(route('incidents.store'), $incidentData->toArray());
 
-        Notification::assertSentTo($admins, IncidentSubmitted::class);
+        Notification::assertSentTo($admins, IncidentSubmittedNotification::class);
     }
 }

--- a/tests/Feature/Investigation/StoreTest.php
+++ b/tests/Feature/Investigation/StoreTest.php
@@ -7,7 +7,7 @@ use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\Investigation;
 use App\Models\User;
-use App\Notifications\Investigation\InvestigationSubmitted;
+use App\Notifications\Investigation\InvestigationSubmittedNotification;
 use App\States\IncidentStatus\Assigned;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\ValidationException;
@@ -47,13 +47,13 @@ class StoreTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, InvestigationSubmitted::class);
+        Notification::assertSentTo($admins, InvestigationSubmittedNotification::class);
 
         $investigation = Investigation::first();
 
         Notification::assertSentTo(
             $admins,
-            function (InvestigationSubmitted $notification, array $channels) use ($investigation, $supervisor) {
+            function (InvestigationSubmittedNotification $notification, array $channels) use ($investigation, $supervisor) {
                 return $notification->investigationId === $investigation->id && $notification->supervisor->id === $supervisor->id;
             }
         );

--- a/tests/Feature/RootCauseAnalysis/StoreTest.php
+++ b/tests/Feature/RootCauseAnalysis/StoreTest.php
@@ -7,7 +7,7 @@ use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\RootCauseAnalysis;
 use App\Models\User;
-use App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmitted;
+use App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmittedNotification;
 use App\States\IncidentStatus\Assigned;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\ValidationException;
@@ -72,13 +72,13 @@ class StoreTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, RootCauseAnalysisSubmitted::class);
+        Notification::assertSentTo($admins, RootCauseAnalysisSubmittedNotification::class);
 
         $rca = RootCauseAnalysis::first();
 
         Notification::assertSentTo(
             $admins,
-            function (RootCauseAnalysisSubmitted $notification, array $channels) use ($rca, $supervisor) {
+            function (RootCauseAnalysisSubmittedNotification $notification, array $channels) use ($rca, $supervisor) {
                 return $notification->rootCauseAnalysisId === $rca->id && $notification->supervisor->id === $supervisor->id;
             }
         );

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -11,8 +11,8 @@ use App\Exceptions\UserNotSupervisorException;
 use App\Mail\IncidentReceived;
 use App\Models\Incident;
 use App\Models\User;
-use App\Notifications\Incident\IncidentReviewRequest;
-use App\Notifications\Incident\IncidentSubmitted;
+use App\Notifications\Incident\IncidentReviewRequestNotification;
+use App\Notifications\Incident\IncidentSubmittedNotification;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\Closed;
 use App\States\IncidentStatus\InReview;
@@ -61,7 +61,7 @@ class IncidentAggregateRootTest extends TestCase
 
         Notification::assertSentTo(
             $admins,
-            function (IncidentReviewRequest $notification, array $channels) use ($incident, $admins, $supervisor) {
+            function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $admins, $supervisor) {
                 $databaseStore = $notification->toArray($admins->first());
 
                 $this->assertEquals(route('incidents.show', $incident->id), $databaseStore['url']);
@@ -94,11 +94,11 @@ class IncidentAggregateRootTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, IncidentReviewRequest::class);
+        Notification::assertSentTo($admins, IncidentReviewRequestNotification::class);
 
         Notification::assertSentTo(
             $admins,
-            function (IncidentReviewRequest $notification, array $channels) use ($incident, $supervisor) {
+            function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
                 return $notification->incidentId === $incident->id && $notification->supervisor->id === $supervisor->id;
             }
         );
@@ -780,8 +780,8 @@ class IncidentAggregateRootTest extends TestCase
         Mail::assertSent(IncidentReceived::class, 1);
         Mail::assertSent(IncidentReceived::class, $user->email);
 
-        Notification::assertSentTo($admins, IncidentSubmitted::class);
-        Notification::assertNotSentTo($user, IncidentSubmitted::class);
+        Notification::assertSentTo($admins, IncidentSubmittedNotification::class);
+        Notification::assertNotSentTo($user, IncidentSubmittedNotification::class);
     }
 
     public function test_create_incident_sends_no_mail_on_reporters_email_not_set(): void
@@ -863,6 +863,6 @@ class IncidentAggregateRootTest extends TestCase
             ->createIncident($incidentData)
             ->persist();
 
-        Notification::assertSentTo($admins, IncidentSubmitted::class);
+        Notification::assertSentTo($admins, IncidentSubmittedNotification::class);
     }
 }

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -10,6 +10,7 @@ use App\Enum\IncidentType;
 use App\Exceptions\UserNotSupervisorException;
 use App\Mail\IncidentReceived;
 use App\Models\Incident;
+use App\Models\Investigation;
 use App\Models\User;
 use App\Notifications\Incident\IncidentReviewRequestNotification;
 use App\Notifications\Incident\IncidentSubmittedNotification;
@@ -163,8 +164,15 @@ class IncidentAggregateRootTest extends TestCase
 
     public function test_return_investigation_sets_returned_status()
     {
+        $admin = User::factory()->create()->syncRoles('admin');
+        $this->actingAs($admin);
+
         $incident = Incident::factory()->create([
             'status' => InReview::class,
+        ]);
+
+        Investigation::factory()->create([
+            'incident_id' => $incident->id,
         ]);
 
         IncidentAggregateRoot::retrieve($incident->id)
@@ -178,8 +186,18 @@ class IncidentAggregateRootTest extends TestCase
 
     public function test_return_investigation_adds_returned_comment()
     {
+        $admin = User::factory()->create()->syncRoles('admin');
+        $this->actingAs($admin);
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
         $incident = Incident::factory()->create([
             'status' => InReview::class,
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        Investigation::factory()->create([
+            'incident_id' => $incident->id,
         ]);
 
         IncidentAggregateRoot::retrieve($incident->id)

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -36,7 +36,7 @@ use Tests\TestCase;
 
 class IncidentAggregateRootTest extends TestCase
 {
-    public function test_sends_investigation_returned_notification_to_admin()
+    public function test_sends_investigation_returned_notification_to_supervisor()
     {
         Notification::fake();
         $admin = User::factory()->create()->syncRoles('admin');
@@ -45,7 +45,7 @@ class IncidentAggregateRootTest extends TestCase
 
         $incident = Incident::factory()->create(['status' => InReview::class, 'supervisor_id' => $supervisor->id]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id
         ]);

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -14,6 +14,7 @@ use App\Models\Investigation;
 use App\Models\User;
 use App\Notifications\Incident\IncidentReviewRequestNotification;
 use App\Notifications\Incident\IncidentSubmittedNotification;
+use App\Notifications\Investigation\InvestigationReturnedNotification;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\Closed;
 use App\States\IncidentStatus\InReview;
@@ -35,6 +36,32 @@ use Tests\TestCase;
 
 class IncidentAggregateRootTest extends TestCase
 {
+    public function test_sends_investigation_returned_notification_to_admin()
+    {
+        Notification::fake();
+        $admin = User::factory()->create()->syncRoles('admin');
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $this->actingAs($admin);
+
+        $incident = Incident::factory()->create(['status' => InReview::class, 'supervisor_id' => $supervisor->id]);
+
+        $investigation = Investigation::factory()->create([
+            'incident_id' => $incident->id,
+            'supervisor_id' => $supervisor->id
+        ]);
+
+        Notification::assertNothingSent();
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->returnInvestigation()
+            ->persist();
+
+        Notification::assertCount(1);
+
+        Notification::assertSentTo($supervisor, InvestigationReturnedNotification::class);
+
+    }
+
     public function test_stores_request_notification_in_database()
     {
         Notification::fake();

--- a/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
+++ b/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
@@ -8,7 +8,7 @@ use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\Investigation;
 use App\Models\User;
-use App\Notifications\Investigation\InvestigationSubmitted;
+use App\Notifications\Investigation\InvestigationSubmittedNotification;
 use App\States\IncidentStatus\Assigned;
 use App\StorableEvents\Investigation\InvestigationCreated;
 use Illuminate\Support\Facades\Notification;
@@ -55,13 +55,13 @@ class InvestigationAggregateRootTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, InvestigationSubmitted::class);
+        Notification::assertSentTo($admins, InvestigationSubmittedNotification::class);
 
         $investigation = Investigation::first();
 
         Notification::assertSentTo(
             $admins,
-            function (InvestigationSubmitted $notification, array $channels) use ($investigation, $supervisor) {
+            function (InvestigationSubmittedNotification $notification, array $channels) use ($investigation, $supervisor) {
                 return $notification->investigationId === $investigation->id && $notification->supervisor->id === $supervisor->id;
             }
         );

--- a/tests/Unit/Aggregates/RootCauseAnalysisAggregateRootTest.php
+++ b/tests/Unit/Aggregates/RootCauseAnalysisAggregateRootTest.php
@@ -8,7 +8,7 @@ use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\RootCauseAnalysis;
 use App\Models\User;
-use App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmitted;
+use App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmittedNotification;
 use App\States\IncidentStatus\Assigned;
 use App\StorableEvents\RootCauseAnalysis\RootCauseAnalysisCreated;
 use Illuminate\Support\Facades\Notification;
@@ -79,13 +79,13 @@ class RootCauseAnalysisAggregateRootTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, RootCauseAnalysisSubmitted::class);
+        Notification::assertSentTo($admins, RootCauseAnalysisSubmittedNotification::class);
 
         $rca = RootCauseAnalysis::first();
 
         Notification::assertSentTo(
             $admins,
-            function (RootCauseAnalysisSubmitted $notification, array $channels) use ($rca, $supervisor) {
+            function (RootCauseAnalysisSubmittedNotification $notification, array $channels) use ($rca, $supervisor) {
                 return $notification->rootCauseAnalysisId === $rca->id && $notification->supervisor->id === $supervisor->id;
             }
         );

--- a/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
@@ -7,7 +7,7 @@ use App\Enum\IncidentType;
 use App\Mail\IncidentReceived;
 use App\Models\Incident;
 use App\Models\User;
-use App\Notifications\Incident\IncidentSubmitted;
+use App\Notifications\Incident\IncidentSubmittedNotification;
 use App\States\IncidentStatus\Opened;
 use App\StorableEvents\Incident\IncidentCreated;
 use Carbon\Carbon;
@@ -235,8 +235,8 @@ class IncidentCreatedTest extends TestCase
         Mail::assertSent(IncidentReceived::class, 1);
         Mail::assertSent(IncidentReceived::class, $user->email);
 
-        Notification::assertSentTo($admins, IncidentSubmitted::class);
-        Notification::assertNotSentTo($user, IncidentSubmitted::class);
+        Notification::assertSentTo($admins, IncidentSubmittedNotification::class);
+        Notification::assertNotSentTo($user, IncidentSubmittedNotification::class);
     }
 
     public function test_new_incident_does_not_notify_reporter_if_reporters_email_not_set(): void
@@ -318,7 +318,7 @@ class IncidentCreatedTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, IncidentSubmitted::class);
-        Notification::assertNotSentTo($user, IncidentSubmitted::class);
+        Notification::assertSentTo($admins, IncidentSubmittedNotification::class);
+        Notification::assertNotSentTo($user, IncidentSubmittedNotification::class);
     }
 }

--- a/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\StoreableEvents\Incident;
 use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\User;
-use App\Notifications\Incident\IncidentReviewRequest;
+use App\Notifications\Incident\IncidentReviewRequestNotification;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\InReview;
 use App\States\IncidentStatus\Opened;
@@ -42,7 +42,7 @@ class IncidentReviewRequestedTest extends TestCase
 
         Notification::assertSentTo(
             $admins,
-            function (IncidentReviewRequest $notification, array $channels) use ($incident, $admins, $supervisor) {
+            function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $admins, $supervisor) {
                 $databaseStore = $notification->toArray($admins->first());
 
                 $this->assertEquals(route('incidents.show', $incident->id), $databaseStore['url']);
@@ -78,7 +78,7 @@ class IncidentReviewRequestedTest extends TestCase
 
         Notification::assertSentTo(
             $admins,
-            function (IncidentReviewRequest $notification, array $channels) use ($incident, $supervisor) {
+            function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
                 return $notification->incidentId === $incident->id && $notification->supervisor->id === $supervisor->id;
             }
         );

--- a/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
@@ -6,7 +6,7 @@ use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\Investigation;
 use App\Models\User;
-use App\Notifications\Investigation\InvestigationSubmitted;
+use App\Notifications\Investigation\InvestigationSubmittedNotification;
 use App\States\IncidentStatus\Assigned;
 use App\StorableEvents\Investigation\InvestigationCreated;
 use Illuminate\Support\Facades\Notification;
@@ -144,11 +144,11 @@ class InvestigationCreatedTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, InvestigationSubmitted::class);
+        Notification::assertSentTo($admins, InvestigationSubmittedNotification::class);
 
         Notification::assertSentTo(
             $admins,
-            function (InvestigationSubmitted $notification, array $channels) use ($aggregateUuid, $supervisor) {
+            function (InvestigationSubmittedNotification $notification, array $channels) use ($aggregateUuid, $supervisor) {
                 return $notification->investigationId === $aggregateUuid && $notification->supervisor->id === $supervisor->id;
             }
         );

--- a/tests/Unit/StoreableEvents/Investigation/InvestigationReturnedTest.php
+++ b/tests/Unit/StoreableEvents/Investigation/InvestigationReturnedTest.php
@@ -7,14 +7,11 @@ use App\Models\Incident;
 use App\Models\Investigation;
 use App\Models\User;
 use App\Notifications\Investigation\InvestigationReturnedNotification;
-use App\Notifications\Investigation\InvestigationSubmittedNotification;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\InReview;
 use App\States\IncidentStatus\Returned;
-use App\StorableEvents\Investigation\InvestigationCreated;
 use App\StorableEvents\Investigation\InvestigationReturned;
 use Illuminate\Support\Facades\Notification;
-use Illuminate\Support\Str;
 use Spatie\ModelStates\Exceptions\TransitionNotFound;
 use Tests\TestCase;
 

--- a/tests/Unit/StoreableEvents/Investigation/InvestigationReturnedTest.php
+++ b/tests/Unit/StoreableEvents/Investigation/InvestigationReturnedTest.php
@@ -4,15 +4,55 @@ namespace Tests\Unit\StoreableEvents\Investigation;
 
 use App\Enum\CommentType;
 use App\Models\Incident;
+use App\Models\Investigation;
+use App\Models\User;
+use App\Notifications\Investigation\InvestigationReturnedNotification;
+use App\Notifications\Investigation\InvestigationSubmittedNotification;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\InReview;
 use App\States\IncidentStatus\Returned;
+use App\StorableEvents\Investigation\InvestigationCreated;
 use App\StorableEvents\Investigation\InvestigationReturned;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
 use Spatie\ModelStates\Exceptions\TransitionNotFound;
 use Tests\TestCase;
 
 class InvestigationReturnedTest extends TestCase
 {
+    public function test_returning_investigation_sends_investigation_returned_notification_to_supervisor()
+    {
+        Notification::fake();
+
+        $admin = User::factory()->create()->syncRoles('admin');
+
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'status' => InReview::class,
+            'supervisor_id' => $supervisor->id
+        ]);
+
+        Investigation::factory()->create([
+                'incident_id' => $incident->id,
+                'supervisor_id' => $supervisor->id
+            ]);
+
+        $event = new InvestigationReturned;
+
+        $event->setMetaData(['user_id' => $admin->id]);
+
+        $event->setAggregateRootUuid($incident->id);
+
+        Notification::assertNothingSent();
+
+        $event->react();
+
+        Notification::assertCount(1);
+
+        Notification::assertSentTo($supervisor, InvestigationReturnedNotification::class);
+    }
+
     public function test_throws_if_not_in_review()
     {
         $this->expectException(TransitionNotFound::class);

--- a/tests/Unit/StoreableEvents/RootCauseAnalysis/RootCauseAnalysisCreatedTest.php
+++ b/tests/Unit/StoreableEvents/RootCauseAnalysis/RootCauseAnalysisCreatedTest.php
@@ -6,7 +6,7 @@ use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\RootCauseAnalysis;
 use App\Models\User;
-use App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmitted;
+use App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmittedNotification;
 use App\States\IncidentStatus\Assigned;
 use App\StorableEvents\RootCauseAnalysis\RootCauseAnalysisCreated;
 use Illuminate\Support\Facades\Notification;
@@ -79,11 +79,11 @@ class RootCauseAnalysisCreatedTest extends TestCase
 
         Notification::assertCount(3);
 
-        Notification::assertSentTo($admins, RootCauseAnalysisSubmitted::class);
+        Notification::assertSentTo($admins, RootCauseAnalysisSubmittedNotification::class);
 
         Notification::assertSentTo(
             $admins,
-            function (RootCauseAnalysisSubmitted $notification, array $channels) use ($aggregateUuid, $supervisor) {
+            function (RootCauseAnalysisSubmittedNotification $notification, array $channels) use ($aggregateUuid, $supervisor) {
                 return $notification->rootCauseAnalysisId === $aggregateUuid && $notification->supervisor->id === $supervisor->id;
             }
         );


### PR DESCRIPTION
# Feature Addition [CLOSES #214]

## Summary

Adds Investigation Returned Notification

## Rationale

Notify supervisors of returned investigation

## Design Documentation

NA

## Changes

- Adds InvestigationReturnedNotification and investigation-returned email
- Adds BaseNotification abstract class which has $url and $message properties and uses Queueable
- Renames all notifications with 'Notification' appended to class name. 

## Impact

- For future notifications, extend BaseNotification as every notification needs a message and url.

## Testing

- Updated Incident Status feature test
- Updated InvestigationReturned event test

## Screenshots/Video

Email:
![image](https://github.com/user-attachments/assets/19bada98-58e3-488d-a956-e69b2d059e9e)


## Checklist

- [ ] Code follows the project's coding standards

- [ ] Unit tests covering the new feature have been added

- [ ] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

Any additional information or context relevant to this PR.
