### PR TITLE
Remove SMS from all notifcations except Incident Submitted

### DIFF
--- a/app/Notifications/Comment/CommentAdded.php
+++ b/app/Notifications/Comment/CommentAdded.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+
 class CommentAdded extends Notification
 {
     use Queueable;

--- a/app/Notifications/Comment/CommentAdded.php
+++ b/app/Notifications/Comment/CommentAdded.php
@@ -6,8 +6,6 @@ use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
-use Illuminate\Notifications\Messages\VonageMessage;
-
 class CommentAdded extends Notification
 {
     use Queueable;

--- a/app/Notifications/Comment/CommentAdded.php
+++ b/app/Notifications/Comment/CommentAdded.php
@@ -5,9 +5,9 @@ namespace App\Notifications\Comment;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Notification;
+use App\Notifications\BaseNotification;
 
-class CommentAdded extends Notification
+class CommentAdded extends BaseNotification
 {
     use Queueable;
 
@@ -17,7 +17,7 @@ class CommentAdded extends Notification
     public function __construct(
         public string $comment,
         public User $user,
-        public string $url  // Add the URL to the constructor
+        public string $url
     ) {
         $this->message = "$this->user->name commented: $this->comment";
     }

--- a/app/Notifications/Comment/CommentAdded.php
+++ b/app/Notifications/Comment/CommentAdded.php
@@ -30,16 +30,7 @@ class CommentAdded extends Notification
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database', 'vonage'];
-    }
-
-    /**
-     * Get the Vonage / SMS representation of the notification.
-     */
-    public function toVonage(object $notifiable): VonageMessage
-    {
-        return (new VonageMessage)
-            ->content($this->message);
+        return ['mail', 'database'];
     }
 
     /**

--- a/app/Notifications/Incident/IncidentReviewRequestNotification.php
+++ b/app/Notifications/Incident/IncidentReviewRequestNotification.php
@@ -27,7 +27,7 @@ class IncidentReviewRequestNotification extends BaseNotification
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database', 'vonage'];
+        return ['mail', 'database'];
     }
 
     /**
@@ -38,15 +38,6 @@ class IncidentReviewRequestNotification extends BaseNotification
         return (new MailMessage)
             ->subject('Incident Follow Up Review Request')
             ->markdown('mail.incident-review-request', ['url' => $this->url]);
-    }
-
-    /**
-     * Get the Vonage / SMS representation of the notification.
-     */
-    public function toVonage(object $notifiable): VonageMessage
-    {
-        return (new VonageMessage)
-            ->content($this->message);
     }
 
     /**

--- a/app/Notifications/Incident/IncidentReviewRequestNotification.php
+++ b/app/Notifications/Incident/IncidentReviewRequestNotification.php
@@ -5,7 +5,6 @@ namespace App\Notifications\Incident;
 use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Messages\VonageMessage;
 
 class IncidentReviewRequestNotification extends BaseNotification
 {

--- a/app/Notifications/Incident/SupervisorAssignedNotification.php
+++ b/app/Notifications/Incident/SupervisorAssignedNotification.php
@@ -28,7 +28,7 @@ class SupervisorAssignedNotification extends BaseNotification
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database', 'vonage'];
+        return ['mail', 'database'];
     }
 
     /**
@@ -43,15 +43,6 @@ class SupervisorAssignedNotification extends BaseNotification
                 'supervisorName' => $this->supervisor->name,
                 'adminName' => $this->admin->name
             ]);
-    }
-
-    /**
-     * Get the Vonage / SMS representation of the notification.
-     */
-    public function toVonage(object $notifiable): VonageMessage
-    {
-        return (new VonageMessage)
-            ->content($this->message);
     }
 
     /**

--- a/app/Notifications/Incident/SupervisorAssignedNotification.php
+++ b/app/Notifications/Incident/SupervisorAssignedNotification.php
@@ -5,7 +5,6 @@ namespace App\Notifications\Incident;
 use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Messages\VonageMessage;
 
 class SupervisorAssignedNotification extends BaseNotification
 {

--- a/app/Notifications/Investigation/InvestigationReturnedNotification.php
+++ b/app/Notifications/Investigation/InvestigationReturnedNotification.php
@@ -32,7 +32,7 @@ class InvestigationReturnedNotification extends BaseNotification
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database', 'vonage'];
+        return ['mail', 'database'];
     }
 
     /**
@@ -43,15 +43,6 @@ class InvestigationReturnedNotification extends BaseNotification
         return (new MailMessage)
             ->subject('Investigation Returned')
             ->markdown('mail.investigation-returned', ['url' => $this->url, 'message' => $this->message]);
-    }
-
-    /**
-     * Get the Vonage / SMS representation of the notification.
-     */
-    public function toVonage(object $notifiable): VonageMessage
-    {
-        return (new VonageMessage)
-            ->content($this->message);
     }
 
     /**

--- a/app/Notifications/Investigation/InvestigationReturnedNotification.php
+++ b/app/Notifications/Investigation/InvestigationReturnedNotification.php
@@ -5,7 +5,6 @@ namespace App\Notifications\Investigation;
 use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Messages\VonageMessage;
 
 class InvestigationReturnedNotification extends BaseNotification
 {

--- a/app/Notifications/Investigation/InvestigationSubmittedNotification.php
+++ b/app/Notifications/Investigation/InvestigationSubmittedNotification.php
@@ -5,7 +5,6 @@ namespace App\Notifications\Investigation;
 use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Messages\VonageMessage;
 
 class InvestigationSubmittedNotification extends BaseNotification
 {
@@ -31,7 +30,7 @@ class InvestigationSubmittedNotification extends BaseNotification
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database', 'vonage'];
+        return ['mail', 'database'];
     }
 
     /**
@@ -42,15 +41,6 @@ class InvestigationSubmittedNotification extends BaseNotification
         return (new MailMessage)
             ->subject('Investigation Submitted')
             ->markdown('mail.investigation-submitted', ['url' => $this->url]);
-    }
-
-    /**
-     * Get the Vonage / SMS representation of the notification.
-     */
-    public function toVonage(object $notifiable): VonageMessage
-    {
-        return (new VonageMessage)
-            ->content($this->message);
     }
 
     /**

--- a/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
+++ b/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
@@ -5,7 +5,6 @@ namespace App\Notifications\RootCauseAnalysis;
 use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Notifications\Messages\VonageMessage;
 
 class RootCauseAnalysisSubmittedNotification extends BaseNotification
 {

--- a/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
+++ b/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
@@ -32,7 +32,7 @@ class RootCauseAnalysisSubmittedNotification extends BaseNotification
      */
     public function via(object $notifiable): array
     {
-        return ['mail', 'database', 'vonage'];
+        return ['mail', 'database'];
     }
 
     /**
@@ -43,15 +43,6 @@ class RootCauseAnalysisSubmittedNotification extends BaseNotification
         return (new MailMessage)
             ->subject('Root Cause Analysis Submitted')
             ->markdown('mail.root-cause-analysis-submitted', ['url' => $this->url]);
-    }
-
-    /**
-     * Get the Vonage / SMS representation of the notification.
-     */
-    public function toVonage(object $notifiable): VonageMessage
-    {
-        return (new VonageMessage)
-            ->content($this->message);
     }
 
     /**


### PR DESCRIPTION
# Feature Addition

CLOSES #233 

## Summary

Removes SMS from all notifications except for Incident Submitted notifications.

## Rationale

UPEI HSE only wants SMS notifications for new incident submissions.

## Design Documentation

N/A

## Changes

Removed 'vonage' from via() and toVonage() from the following:
- CommentAdded.php
- IncidentReviewRequestNotification.php
- InvestigationReturnedNotification.php
- InvestigationSubmittedNotification.php
- RootCauseAnalysisSubmittedNotification.php
- SupervisorAssignedNotification

## Impact

Removes ability for the previously mentioned notifications to send SMS.

## Testing

Removing SMS did not affect any existing tests.

## Screenshots/Video

N/A

## Checklist

- [x] Code follows the project's coding standards

- [ ] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

N/A
