### PR TITLE
Update Incident Received Email

### DIFF
--- a/app/Mail/IncidentReceived.php
+++ b/app/Mail/IncidentReceived.php
@@ -13,14 +13,14 @@ class IncidentReceived extends Mailable
     use Queueable;
     use SerializesModels;
 
-    public string $incidentUrl;
+    public string $url;
 
     /**
      * Create a new message instance.
      */
-    public function __construct(public string $incidentUuid)
+    public function __construct(public string $incidentId)
     {
-        $this->incidentUrl = route('incidents.show', ['incident' => $this->incidentUuid]);
+        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
     }
 
     /**
@@ -41,7 +41,7 @@ class IncidentReceived extends Mailable
         return new Content(
             markdown: 'mail.incident-received',
             with: [
-                'incidentUrl' => $this->incidentUrl,
+                'url' => $this->url,
             ],
         );
     }

--- a/app/Mail/IncidentReceived.php
+++ b/app/Mail/IncidentReceived.php
@@ -13,6 +13,16 @@ class IncidentReceived extends Mailable
     use Queueable;
     use SerializesModels;
 
+    public string $incidentUrl;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(public string $incidentUuid)
+    {
+        $this->incidentUrl = route('incidents.show', ['incident' => $this->incidentUuid]);
+    }
+
     /**
      * Get the message envelope.
      */
@@ -30,6 +40,9 @@ class IncidentReceived extends Mailable
     {
         return new Content(
             markdown: 'mail.incident-received',
+            with: [
+                'incidentUrl' => $this->incidentUrl,
+            ],
         );
     }
 

--- a/app/StorableEvents/Incident/IncidentCreated.php
+++ b/app/StorableEvents/Incident/IncidentCreated.php
@@ -88,7 +88,7 @@ class IncidentCreated extends StoredEvent
     public function react()
     {
         if ($this->reporters_email) {
-            Mail::to($this->reporters_email)->send(new IncidentReceived);
+            Mail::to($this->reporters_email)->send(new IncidentReceived($this->aggregateRootUuid()));
         }
 
         $admins = User::role('admin')->get();

--- a/resources/views/mail/incident-received.blade.php
+++ b/resources/views/mail/incident-received.blade.php
@@ -1,9 +1,12 @@
 <x-mail::message>
 # Incident Received
 
-We have received your incident and appreciate you taking the time to inform us.
-Our team will review the details and take appropriate action as soon as possible.
+Thank you for submitting this incident report. HSE may reach out to you for follow up or additional questions. You may add any additional information to this file by clicking the below link:
+
+<x-mail::button :url="$incidentUrl">
+    View Incident
+</x-mail::button>
 
 Thanks,<br>
-{{ config('app.name') }}
+UPEI Health, Safety, and Environment
 </x-mail::message>

--- a/resources/views/mail/incident-received.blade.php
+++ b/resources/views/mail/incident-received.blade.php
@@ -3,7 +3,7 @@
 
 Thank you for submitting this incident report. HSE may reach out to you for follow up or additional questions. You may add any additional information to this file by clicking the below link:
 
-<x-mail::button :url="$incidentUrl">
+<x-mail::button :url="$url">
     View Incident
 </x-mail::button>
 


### PR DESCRIPTION
# Feature Addition 

CLOSES #204
CLOSES #234

## Summary

Updated incident-received.blade.php to have the correct message.

Updated IncidentCreated.php to receive an incident ID to link in the incident received email (if it should link to something different, then this can be changed later on)

Updated IncidentReceived.php to pass in the incidentID. Again, if the email should link to something different, then this can be easily changed.

## Rationale

Client gave us the template they use when someone submits a new incident. This change will put that template into effect.

## Design Documentation

N/A

## Changes

Changes the message in incident-received.blade.php.

## Impact

N/A

## Testing

N/A

## Screenshots/Video

![image](https://github.com/user-attachments/assets/5c3a980e-fb2a-443e-a3b6-5818023fa2a3)

## Checklist

- [x] Code follows the project's coding standards

- [ ] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

N/A
