### PR TITLE
Incident Slugs

### DIFF
--- a/app/Http/Controllers/Investigation/InvestigationController.php
+++ b/app/Http/Controllers/Investigation/InvestigationController.php
@@ -48,8 +48,6 @@ class InvestigationController extends Controller
     {
         $this->authorize('view', $investigation);
 
-        $investigation->load('incident');
-
         return Inertia::render('Investigation/Show', ['investigation' => $investigation->load(['incident', 'supervisor'])]);
     }
 

--- a/app/Http/Controllers/RootCauseAnalysis/RootCauseAnalysisController.php
+++ b/app/Http/Controllers/RootCauseAnalysis/RootCauseAnalysisController.php
@@ -44,6 +44,7 @@ class RootCauseAnalysisController extends Controller
     public function show(Incident $incident, RootCauseAnalysis $rootCauseAnalysis)
     {
         $this->authorize('view', $rootCauseAnalysis);
+
         return Inertia::render('RootCauseAnalysis/Show', [
             'rca' => $rootCauseAnalysis->load(['incident', 'supervisor'])
         ]);

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -19,6 +19,30 @@ class Incident extends Model
     use SoftDeletes;
     use Searchable;
 
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($incident) {
+            $year = now()->format('Y-');
+
+            $latestId = self::getNextIdForYear($year);
+
+            $incident->slug = $year . str_pad($latestId, 6, '0', STR_PAD_LEFT);
+        });
+    }
+
+    private static function getNextIdForYear(string $year): int
+    {
+        // Fetch the latest ID for the current year
+        $latestItem = self::where('slug', 'like', $year . '%')
+            ->orderBy('slug', 'desc')
+            ->first();
+
+        // If no record exists for the current year, start from 1
+        return $latestItem ? (int) substr($latestItem->slug, -6) + 1 : 1;
+    }
+
     protected function casts(): array
     {
         return [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,11 @@
 
 namespace App\Providers;
 
+use App\Models\Incident;
 use App\Policies\DashboardPolicy;
 use App\Policies\ReportPolicy;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
 
@@ -24,6 +26,12 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Vite::prefetch(concurrency: 3);
+
+        Route::bind('incident', function (string $value) {
+            return Incident::where('id', $value)
+                ->orWhere('slug', $value)
+                ->firstOrFail();
+        });
 
         Gate::define('view-report-page', [ReportPolicy::class, 'view']);
 

--- a/database/migrations/2025_01_10_151039_create_incidents_table.php
+++ b/database/migrations/2025_01_10_151039_create_incidents_table.php
@@ -13,6 +13,8 @@ return new class () extends Migration {
         Schema::create('incidents', function (Blueprint $table) {
             $table->uuid('id')->primary();
 
+            $table->string('slug')->unique();
+
             $table->boolean('anonymous');
             $table->boolean('on_behalf');
             $table->boolean('on_behalf_anonymous');

--- a/resources/js/Helpers/Incident/statusUpdates.ts
+++ b/resources/js/Helpers/Incident/statusUpdates.ts
@@ -8,7 +8,7 @@ export const returnInvestigation = (
     onSuccess: () => void
 ) => {
     setIsLoading(true);
-    router.patch(route('incidents.return-investigation', { incident: incident.id }), undefined, {
+    router.patch(route('incidents.return-investigation', { incident: incident.slug }), undefined, {
         onSuccess: (_) => onSuccess(),
         onFinish: (_) => setIsLoading(false),
         preserveScroll: true,
@@ -21,7 +21,7 @@ export const returnRCA = (
     onSuccess: () => void
 ) => {
     setIsLoading(true);
-    router.patch(route('incidents.return-rca', { incident: incident.id }), undefined, {
+    router.patch(route('incidents.return-rca', { incident: incident.slug }), undefined, {
         onSuccess: (_) => onSuccess(),
         onFinish: (_) => setIsLoading(false),
         preserveScroll: true,
@@ -34,7 +34,7 @@ export const closeIncident = (
     onSuccess: () => void
 ) => {
     setIsLoading(true);
-    router.patch(route('incidents.close', { incident: incident.id }), undefined, {
+    router.patch(route('incidents.close', { incident: incident.slug }), undefined, {
         onSuccess: (_) => onSuccess(),
         onFinish: (_) => setIsLoading(false),
         preserveScroll: true,
@@ -47,7 +47,7 @@ export const reopenIncident = (
     onSuccess: () => void
 ) => {
     setIsLoading(true);
-    router.patch(route('incidents.reopen', { incident: incident.id }), undefined, {
+    router.patch(route('incidents.reopen', { incident: incident.slug }), undefined, {
         onSuccess: (_) => onSuccess(),
         onFinish: (_) => setIsLoading(false),
         preserveScroll: true,
@@ -62,7 +62,7 @@ export const assignSupervisor = (
 ) => {
     setIsLoading(true);
     router.patch(
-        route('incidents.assign-supervisor', { incident: incident.id }),
+        route('incidents.assign-supervisor', { incident: incident.slug }),
         { supervisor_id: supervisorId },
         {
             onSuccess: (_) => onSuccess(),
@@ -78,7 +78,7 @@ export const unassignSupervisor = (
     onSuccess: () => void
 ) => {
     setIsLoading(true);
-    router.patch(route('incidents.unassign-supervisor', { incident: incident.id }), undefined, {
+    router.patch(route('incidents.unassign-supervisor', { incident: incident.slug }), undefined, {
         onSuccess: (_) => onSuccess(),
         onFinish: (_) => setIsLoading(false),
         preserveScroll: true,

--- a/resources/js/Layouts/Partials/Searchbar.tsx
+++ b/resources/js/Layouts/Partials/Searchbar.tsx
@@ -226,14 +226,14 @@ export default function Searchbar({ isOpen, setIsOpen }: CommandPaletteProps) {
                             >
                                 {incidents.map((incident) => (
                                     <ComboboxOption
-                                        key={incident.id}
-                                        value={incident.id}
+                                        key={incident.slug}
+                                        value={incident.slug}
                                         className="select-none px-4 py-2
                                        hover:bg-upei-green-500 hover:text-white hover:cursor-pointer
                                        focus:outline-none focus:ring-0 focus:shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
                                         onClick={() =>
                                             router.get(
-                                                route('incidents.show', { incident: incident.id })
+                                                route('incidents.show', { incident: incident.slug })
                                             )
                                         }
                                     >

--- a/resources/js/Pages/Dashboard/Partials/OverviewTable.tsx
+++ b/resources/js/Pages/Dashboard/Partials/OverviewTable.tsx
@@ -50,9 +50,9 @@ export default function OverviewTable({ incidents }: { incidents: Incident[] }) 
                                         as="tr"
                                         className="cursor-pointer hover:bg-gray-50"
                                         href={route('incidents.show', {
-                                            incident: incident.id,
+                                            incident: incident.slug,
                                         })}
-                                        key={incident.id}
+                                        key={incident.slug}
                                     >
                                         <td className="px-3 py-4 text-sm text-gray-500 ">
                                             {nameFilter(incident)[0]} {nameFilter(incident)[1]}
@@ -75,7 +75,7 @@ export default function OverviewTable({ incidents }: { incidents: Incident[] }) 
                                         <td className="py-4 pl-3 pr-4 text-right text-sm font-medium md:pr-6">
                                             <Link
                                                 href={route('incidents.show', {
-                                                    incident: incident.id,
+                                                    incident: incident.slug,
                                                 })}
                                                 className="text-upei-green-500 hover:text-upei-green-600"
                                             >

--- a/resources/js/Pages/Dashboard/UserDashboard.tsx
+++ b/resources/js/Pages/Dashboard/UserDashboard.tsx
@@ -164,9 +164,9 @@ export default function UserDashboard({
                                                         as="tr"
                                                         className="cursor-pointer hover:bg-gray-50"
                                                         href={route('incidents.show', {
-                                                            incident: incident.id,
+                                                            incident: incident.slug,
                                                         })}
-                                                        key={incident.id}
+                                                        key={incident.slug}
                                                     >
                                                         <td className="px-3 py-4 text-sm w-[70rem] text-gray-500 ">
                                                             <div className="line-clamp-3">
@@ -187,7 +187,7 @@ export default function UserDashboard({
                                                         <td className="py-4 pl-3 pr-4 text-right text-sm font-medium md:pr-6">
                                                             <Link
                                                                 href={route('incidents.show', {
-                                                                    incident: incident.id,
+                                                                    incident: incident.slug,
                                                                 })}
                                                                 className="text-upei-green-500 hover:text-upei-green-600"
                                                             >

--- a/resources/js/Pages/Incident/Index.tsx
+++ b/resources/js/Pages/Incident/Index.tsx
@@ -504,9 +504,9 @@ export default function Index({
                                                 as="tr"
                                                 className="cursor-pointer hover:bg-gray-50"
                                                 href={route('incidents.show', {
-                                                    incident: incident.id,
+                                                    incident: incident.slug,
                                                 })}
-                                                key={incident.id}
+                                                key={incident.slug}
                                             >
                                                 <td className="hidden px-6 py-4 text-sm text-gray-500 md:table-cell">
                                                     {new Date(
@@ -549,7 +549,7 @@ export default function Index({
                                                 <td className="py-4 pl-3 pr-4 text-right text-sm font-medium md:pr-6">
                                                     <Link
                                                         href={route('incidents.show', {
-                                                            incident: incident.id,
+                                                            incident: incident.slug,
                                                         })}
                                                         className="text-upei-green-500 hover:text-upei-green-600"
                                                     >

--- a/resources/js/Pages/Incident/Partials/ShowComponents/AdminActionsComponents/StatusUpdate.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/AdminActionsComponents/StatusUpdate.tsx
@@ -53,7 +53,7 @@ export default function StatusUpdate({ incident }: { incident: Incident }) {
                                             <Link
                                                 className="text-sm cursor-pointer text-blue-500 hover:text-blue-400"
                                                 href={route('incidents.investigations.show', {
-                                                    incident: incident.id,
+                                                    incident: incident.slug,
                                                     investigation: investigation.id,
                                                 })}
                                             >
@@ -74,7 +74,7 @@ export default function StatusUpdate({ incident }: { incident: Incident }) {
                                             <Link
                                                 className="text-sm cursor-pointer text-blue-500 hover:text-blue-400"
                                                 href={route('incidents.root-cause-analyses.show', {
-                                                    incident: rca.incident_id,
+                                                    incident: incident.slug,
                                                     root_cause_analysis: rca.id,
                                                 })}
                                             >
@@ -114,7 +114,7 @@ export default function StatusUpdate({ incident }: { incident: Incident }) {
                                                 returnRCA(incident, setIsLoading, () =>
                                                     router.get(
                                                         route('incidents.show', {
-                                                            incident: incident.id,
+                                                            incident: incident.slug,
                                                         })
                                                     )
                                                 ),

--- a/resources/js/Pages/Incident/Partials/ShowComponents/AdminActionsComponents/SupervisorUpdate.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/AdminActionsComponents/SupervisorUpdate.tsx
@@ -51,7 +51,7 @@ export default function SupervisorUpdate({ incident, supervisors, roles }: Super
                     }
                     setIsUserFormOpen(false);
                 }}
-                assignToIncidentId={incident.id}
+                assignToIncidentId={incident.slug}
             />
             <label className="block text-sm/6 font-medium text-gray-900 mt-6">
                 Supervisor Management

--- a/resources/js/Pages/Incident/Partials/ShowComponents/IncidentHeader.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/IncidentHeader.tsx
@@ -14,7 +14,7 @@ export default function IncidentHeader({ incident }: { incident: Incident }) {
                             <ApplicationLogo className="size-[6rem] flex-none rounded-full ring-gray-900/10" />
                             <h1>
                                 <div className="text-sm/6 text-gray-500">
-                                    Incident <span className="text-gray-700">{incident.id}</span>
+                                    Incident <span className="text-gray-700">{incident.slug}</span>
                                 </div>
                                 <div className="mt-1 text-base font-semibold text-gray-900">
                                     UPEI Health & Safety

--- a/resources/js/Pages/Incident/Partials/ShowComponents/IncidentSupervisorActions.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/IncidentSupervisorActions.tsx
@@ -32,7 +32,7 @@ export default function IncidentSupervisorActions({
                                         <Link
                                             className="text-sm cursor-pointer text-blue-500 hover:text-blue-400"
                                             href={route('incidents.investigations.show', {
-                                                incident: incident.id,
+                                                incident: incident.slug,
                                                 investigation: investigation.id,
                                             })}
                                         >
@@ -54,7 +54,7 @@ export default function IncidentSupervisorActions({
                                         <Link
                                             className="text-sm cursor-pointer text-blue-500 hover:text-blue-400"
                                             href={route('incidents.root-cause-analyses.show', {
-                                                incident: incident.id,
+                                                incident: incident.slug,
                                                 root_cause_analysis: rca.id,
                                             })}
                                         >
@@ -72,7 +72,7 @@ export default function IncidentSupervisorActions({
                                 <>
                                     <Link
                                         href={route('incidents.investigations.create', {
-                                            incident: incident.id,
+                                            incident: incident.slug,
                                         })}
                                         as="button"
                                         className="text-center rounded-md bg-upei-green-500 px-3 py-2  text-sm font-semibold text-white shadow-sm hover:bg-upei-green-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-upei-green-600"
@@ -81,7 +81,7 @@ export default function IncidentSupervisorActions({
                                     </Link>
                                     <Link
                                         href={route('incidents.root-cause-analyses.create', {
-                                            incident: incident.id,
+                                            incident: incident.slug,
                                         })}
                                         as="button"
                                         className="text-center rounded-md bg-upei-green-500 px-3 py-2  text-sm font-semibold text-white shadow-sm hover:bg-upei-green-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-upei-green-600"
@@ -93,7 +93,7 @@ export default function IncidentSupervisorActions({
                             {canRequestReview && (
                                 <Link
                                     href={route('incidents.request-review', {
-                                        incident: incident.id,
+                                        incident: incident.slug,
                                     })}
                                     method="patch"
                                     as="button"

--- a/resources/js/Pages/Incident/Partials/ShowComponents/IncidentUserActions.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/IncidentUserActions.tsx
@@ -16,7 +16,7 @@ export default function IncidentUserActions({ incident }: { incident: Incident }
     });
 
     const handleSubmit = () => {
-        patch(route('incidents.additional-information', { incident: incident.id }), {
+        patch(route('incidents.additional-information', { incident: incident.slug }), {
             onSuccess: () => {
                 setIsModalOpen(false);
                 setData('additional_information', '');

--- a/resources/js/Pages/Incident/Show.tsx
+++ b/resources/js/Pages/Incident/Show.tsx
@@ -35,7 +35,7 @@ export default function Show({
 
     function addComment(e: FormEvent<HTMLFormElement>) {
         e.preventDefault();
-        post(route('incidents.comments.store', { incident: incident.id }), {
+        post(route('incidents.comments.store', { incident: incident.slug }), {
             preserveScroll: true,
             onSuccess: () => reset(),
         });

--- a/resources/js/Pages/Incident/Stages/VictimInformationStage.tsx
+++ b/resources/js/Pages/Incident/Stages/VictimInformationStage.tsx
@@ -5,8 +5,6 @@ import TextArea from '@/Components/TextArea';
 
 export default function VictimInformationStage({ formData, setFormData }: StageProps) {
     useEffect(() => {
-        console.log('RUNS');
-
         if (!(formData.work_related && formData.has_injury) && formData.workers_comp_submitted) {
             setFormData('workers_comp_submitted', false);
         }

--- a/resources/js/Pages/Investigation/Create.tsx
+++ b/resources/js/Pages/Investigation/Create.tsx
@@ -39,7 +39,7 @@ export default function Create({ incident }: { incident: Incident }) {
 
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        post(route('incidents.investigations.store', { incident: incident.id }));
+        post(route('incidents.investigations.store', { incident: incident.slug }));
     };
 
     const toggleCheckbox = (category: keyof InvestigationData, value: string) => {

--- a/resources/js/Pages/Investigation/Partials/ShowComponents/InvestigationAdminActions.tsx
+++ b/resources/js/Pages/Investigation/Partials/ShowComponents/InvestigationAdminActions.tsx
@@ -46,7 +46,7 @@ export default function InvestigationAdminActions({
                                                                 router.get(
                                                                     route('incidents.show', {
                                                                         incident:
-                                                                            investigation.incident_id,
+                                                                            investigation.incident.slug,
                                                                     })
                                                                 )
                                                         ),
@@ -71,7 +71,7 @@ export default function InvestigationAdminActions({
                                                             router.get(
                                                                 route('incidents.show', {
                                                                     incident:
-                                                                        investigation.incident_id,
+                                                                        investigation.incident.slug,
                                                                 })
                                                             )
                                                     ),

--- a/resources/js/Pages/Investigation/Partials/ShowComponents/InvestigationInformationPanel.tsx
+++ b/resources/js/Pages/Investigation/Partials/ShowComponents/InvestigationInformationPanel.tsx
@@ -10,13 +10,13 @@ export default function InvestigationInformationPanel({
     return (
         <div className="bg-white -mx-4 px-4 py-8 shadow-sm ring-1 ring-gray-900/5 sm:mx-0 sm:rounded-lg sm:px-8 sm:pb-14 lg:col-span-2 lg:row-span-2 lg:row-end-2 xl:px-16 xl:pb-20 xl:pt-16">
             <div className="flex items-center space-x-2">
-                <Link href={route('incidents.show', { incident: investigation.incident_id })}>
+                <Link href={route('incidents.show', { incident: investigation.incident.slug })}>
                     <ArrowLeftIcon className="size-6 text-gray-900 hover:text-gray-500" />
                 </Link>
                 <h2 className="font-semibold text-gray-900 text-2xl">Investigation</h2>
             </div>
             <div className='className="font-semibold text-gray-800 my-4'>
-                Incident: {investigation.incident_id}
+                Incident: {investigation.incident.slug}
             </div>
             <div className='className="font-semibold text-gray-800 my-4'>
                 Investigation provided by: {investigation.supervisor.name}

--- a/resources/js/Pages/RootCauseAnalysis/Create.tsx
+++ b/resources/js/Pages/RootCauseAnalysis/Create.tsx
@@ -60,7 +60,7 @@ export default function Create({ incident }: { incident: Incident }) {
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
 
-        post(route('incidents.root-cause-analyses.store', { incident: incident.id }));
+        post(route('incidents.root-cause-analyses.store', { incident: incident.slug }));
     };
     return (
         <Authenticated>

--- a/resources/js/Pages/RootCauseAnalysis/Partials/ShowComponents/RootCauseAnalysisAdminActions.tsx
+++ b/resources/js/Pages/RootCauseAnalysis/Partials/ShowComponents/RootCauseAnalysisAdminActions.tsx
@@ -36,7 +36,7 @@ export default function RootCauseAnalysisAdminActions({ rca }: { rca: RootCauseA
                                                         returnRCA(rca.incident, setIsLoading, () =>
                                                             router.get(
                                                                 route('incidents.show', {
-                                                                    incident: rca.incident_id,
+                                                                    incident: rca.incident.slug,
                                                                 })
                                                             )
                                                         ),
@@ -57,7 +57,7 @@ export default function RootCauseAnalysisAdminActions({ rca }: { rca: RootCauseA
                                                     closeIncident(rca.incident, setIsLoading, () =>
                                                         router.get(
                                                             route('incidents.show', {
-                                                                incident: rca.incident_id,
+                                                                incident: rca.incident.slug,
                                                             })
                                                         )
                                                     ),

--- a/resources/js/Pages/RootCauseAnalysis/Partials/ShowComponents/RootCauseAnalysisInformationPanel.tsx
+++ b/resources/js/Pages/RootCauseAnalysis/Partials/ShowComponents/RootCauseAnalysisInformationPanel.tsx
@@ -6,13 +6,13 @@ export default function RootCauseAnalysisInformationPanel({ rca }: { rca: RootCa
     return (
         <div className="bg-white -mx-4 px-4 py-8 shadow-sm ring-1 ring-gray-900/5 sm:mx-0 sm:rounded-lg sm:px-8 sm:pb-14 lg:col-span-2 lg:row-span-2 lg:row-end-2 xl:px-16 xl:pb-20 xl:pt-16">
             <div className="flex items-center space-x-2">
-                <Link href={route('incidents.show', { incident: rca.incident_id })}>
+                <Link href={route('incidents.show', { incident: rca.incident.slug })}>
                     <ArrowLeftIcon className="size-6 text-gray-900 hover:text-gray-500" />
                 </Link>
                 <h2 className="font-semibold text-gray-900 text-2xl">Root Cause Analysis</h2>
             </div>
             <div className='className="font-semibold text-gray-800 my-4'>
-                Incident: {rca.incident_id}
+                Incident: {rca.incident.slug}
             </div>
             <div className='className="font-semibold text-gray-800 my-4'>
                 Root Cause Analysis provided by: {rca.supervisor.name}

--- a/resources/js/Pages/RootCauseAnalysis/Show.tsx
+++ b/resources/js/Pages/RootCauseAnalysis/Show.tsx
@@ -6,9 +6,9 @@ import classNames from '@/Filters/classNames';
 import RootCauseAnalysisAdminActions from '@/Pages/RootCauseAnalysis/Partials/ShowComponents/RootCauseAnalysisAdminActions';
 import RootCauseAnalysisInformationPanel from '@/Pages/RootCauseAnalysis/Partials/ShowComponents/RootCauseAnalysisInformationPanel';
 
-export default function Show({ rca, incident }: { rca: RootCauseAnalysis; incident: Incident }) {
+export default function Show({ rca }: { rca: RootCauseAnalysis; incident: Incident }) {
     const { user } = usePage().props.auth;
-    console.log(rca);
+
     return (
         <Authenticated>
             <Head title="Root Cause Analysis" />

--- a/resources/js/types/incident/Incident.ts
+++ b/resources/js/types/incident/Incident.ts
@@ -9,6 +9,7 @@ import { AdditionalInformation } from '@/types/incident/AdditionalInformation';
 
 export interface Incident {
     id: string;
+    slug: string;
     anonymous: boolean;
     on_behalf: boolean;
     on_behalf_anonymous: boolean;

--- a/tests/Unit/Models/IncidentTest.php
+++ b/tests/Unit/Models/IncidentTest.php
@@ -11,10 +11,36 @@ use App\States\IncidentStatus\InReview;
 use App\States\IncidentStatus\Opened;
 use App\States\IncidentStatus\Reopened;
 use App\States\IncidentStatus\Returned;
+use Carbon\Carbon;
 use Tests\TestCase;
 
 class IncidentTest extends TestCase
 {
+    public function test_slug_count_resets_on_year_change()
+    {
+        $incident = Incident::factory()->create();
+        $next = Incident::factory()->create();
+
+        $this->assertEquals('2025-000001', $incident->slug);
+        $this->assertEquals('2025-000002', $next->slug);
+
+        Carbon::setTestNow('2026-04-09');
+
+        $incident = Incident::factory()->create();
+        $next = Incident::factory()->create();
+
+        $this->assertEquals('2026-000001', $incident->slug);
+        $this->assertEquals('2026-000002', $next->slug);
+    }
+    public function test_slug_generates_on_create()
+    {
+        $incident = Incident::factory()->create();
+        $next = Incident::factory()->create();
+
+        $this->assertEquals('2025-000001', $incident->slug);
+
+        $this->assertEquals('2025-000002', $next->slug);
+    }
     public function test_sort_scope_status_sorts_by_custom_order()
     {
         Incident::factory()->create(['status' => Assigned::class]);


### PR DESCRIPTION
# Feature Addition

CLOSES #237

## Summary

Adds a slug property to incidents.

## Rationale

UUID's were long and not easily referenceable.

## Design Documentation

N/A

## Changes

- Adds an autogenerated field slug to incidents, formatted as YEAR-XXXXXX
  - XXXXXX increments with each new incident and resets when a new year occurrs

## Impact

N/A

## Testing

Added tests to verify count resets on new year, and increments correctly.

## Screenshots/Video

N/A

## Checklist

- [ ] Code follows the project's coding standards

- [ ] Unit tests covering the new feature have been added

- [ ] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

N/A