### PR TITLE
Fixes comment notification sends to self and comment policy allowing user to send comments

### DIFF
--- a/app/Notifications/Comment/CommentAdded.php
+++ b/app/Notifications/Comment/CommentAdded.php
@@ -19,7 +19,7 @@ class CommentAdded extends BaseNotification
         public User $user,
         public string $url
     ) {
-        $this->message = "$this->user->name commented: $this->comment";
+        $this->message = "{$this->user->name} commented: $this->comment";
     }
 
     /**

--- a/app/Policies/IncidentPolicy.php
+++ b/app/Policies/IncidentPolicy.php
@@ -77,7 +77,7 @@ class IncidentPolicy
 
     public function addComment(User $user, Incident $incident): bool
     {
-        return $this->view($user, $incident);
+        return $this->view($user, $incident) && $user->can('add comments');
     }
 
     public function searchIncidents(User $user, Builder $incidentQuery): bool

--- a/app/StorableEvents/Comment/CommentCreated.php
+++ b/app/StorableEvents/Comment/CommentCreated.php
@@ -40,10 +40,10 @@ class CommentCreated extends StoredEvent
 
         if ($commentable) {
             $url = route('incidents.show', ['incident' => $this->commentable_id]);
-            if ($commentable->supervisor) {
+            if ($commentable->supervisor && $commentable->supervisor->id !== $this->metaData['user_id']) {
                 Notification::send($commentable->supervisor, new CommentAdded($this->content, $commenter, $url));
             }
-            $admins = User::role('admin')->get();
+            $admins = User::role('admin')->whereNot('id', '=', $this->metaData['user_id'])->get();
             Notification::send($admins, new CommentAdded($this->content, $commenter, $url));
         }
     }

--- a/app/StorableEvents/Comment/CommentCreated.php
+++ b/app/StorableEvents/Comment/CommentCreated.php
@@ -40,11 +40,16 @@ class CommentCreated extends StoredEvent
 
         if ($commentable) {
             $url = route('incidents.show', ['incident' => $this->commentable_id]);
+
+            $notification = new CommentAdded($this->content, $commenter, $url);
+
             if ($commentable->supervisor && $commentable->supervisor->id !== $this->metaData['user_id']) {
-                Notification::send($commentable->supervisor, new CommentAdded($this->content, $commenter, $url));
+                Notification::send($commentable->supervisor, $notification);
             }
-            $admins = User::role('admin')->whereNot('id', '=', $this->metaData['user_id'])->get();
-            Notification::send($admins, new CommentAdded($this->content, $commenter, $url));
+
+            $admins = User::role('admin')->whereKeyNot($this->metaData['user_id'])->get();
+
+            Notification::send($admins, $notification);
         }
     }
 }

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -22,6 +22,7 @@ class RolesAndPermissionsSeeder extends Seeder
         Permission::firstOrCreate(['name' => 'provide incident follow-up']);
         Permission::firstOrCreate(['name' => 'view any incident follow-up']);
         Permission::firstOrCreate(['name' => 'manage users']);
+        Permission::firstOrCreate(['name' => 'add comments']);
 
 
         // create roles and assign created permissions
@@ -33,18 +34,20 @@ class RolesAndPermissionsSeeder extends Seeder
                 'view reports',
                 'view any incident follow-up',
                 'manage users',
+                'add comments',
             ]);
 
         Role::firstOrCreate(['name' => 'supervisor'])
             ->syncPermissions([
                 'view assigned incidents',
                 'view own incidents',
-                'provide incident follow-up'
+                'provide incident follow-up',
+                'add comments',
             ]);
 
         Role::firstOrCreate(['name' => 'user'])
             ->syncPermissions([
-                'view own incidents'
+                'view own incidents',
             ]);
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,8 +3,8 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         stopOnFailure="false"
-         stopOnDefect="false"
+         stopOnFailure="true"
+         stopOnDefect="true"
 >
     <testsuites>
         <testsuite name="Unit">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,8 +3,8 @@
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
-         stopOnFailure="true"
-         stopOnDefect="true"
+         stopOnFailure="false"
+         stopOnDefect="false"
 >
     <testsuites>
         <testsuite name="Unit">

--- a/tests/Feature/Incident/AddCommentTest.php
+++ b/tests/Feature/Incident/AddCommentTest.php
@@ -144,6 +144,8 @@ class AddCommentTest extends TestCase
 
         $supervisor = User::factory()->create()->syncRoles('supervisor');
 
+        $commenter = User::factory()->create()->syncRoles('admin');
+
         $incident = Incident::factory()->create([
             'supervisor_id' => $supervisor->id,
         ]);
@@ -152,7 +154,7 @@ class AddCommentTest extends TestCase
             'content' => 'Test comment for supervisor notification',
         ]);
 
-        $this->actingAs($supervisor);
+        $this->actingAs($commenter);
 
         $response = $this->post(route('incidents.comments.store', ['incident' => $incident->id]), $commentData->toArray());
 

--- a/tests/Feature/Incident/AddCommentTest.php
+++ b/tests/Feature/Incident/AddCommentTest.php
@@ -15,6 +15,92 @@ use Tests\TestCase;
 
 class AddCommentTest extends TestCase
 {
+    public function test_admin_can_comment_on_incidents()
+    {
+        $admin = User::factory()->create()->syncRoles('admin');
+
+        $this->actingAs($admin);
+
+        $incident = Incident::factory()->create();
+
+        $commentData = CommentData::from([
+            'content' => 'test comment'
+        ]);
+
+        $this->assertDatabaseCount('comments', 0);
+
+        $response = $this->post(route('incidents.comments.store', ['incident' => $incident->id]), $commentData->toArray());
+
+        $response->assertRedirect();
+        $this->assertDatabaseCount('comments', 1);
+    }
+
+    public function test_supervisor_cant_comment_on_unassigned_incident()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create();
+
+        $commentData = CommentData::from([
+            'content' => 'test comment'
+        ]);
+
+        $this->assertDatabaseCount('comments', 0);
+
+        $response = $this->post(route('incidents.comments.store', ['incident' => $incident->id]), $commentData->toArray());
+
+        $response->assertForbidden();
+        $this->assertDatabaseCount('comments', 0);
+    }
+
+    public function test_supervisor_can_comment_on_assigned_incident()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+        ]);
+
+        $commentData = CommentData::from([
+            'content' => 'test comment'
+        ]);
+
+        $this->assertDatabaseCount('comments', 0);
+
+        $response = $this->post(route('incidents.comments.store', ['incident' => $incident->id]), $commentData->toArray());
+
+        $response->assertRedirect();
+        $this->assertDatabaseCount('comments', 1);
+    }
+
+    public function test_user_can_not_create_comments()
+    {
+        $user = User::factory()->create([
+            'email' => 'a@b.com'
+        ])->syncRoles('user');
+
+        $this->actingAs($user);
+
+        $incident = Incident::factory()->create([
+            'reporters_email' => $user->email,
+        ]);
+
+        $commentData = CommentData::from([
+            'content' => 'test comment'
+        ]);
+
+        $this->assertDatabaseCount('comments', 0);
+
+        $response = $this->post(route('incidents.comments.store', ['incident' => $incident->id]), $commentData->toArray());
+
+        $response->assertForbidden();
+        $this->assertDatabaseCount('comments', 0);
+    }
+
     public function test_comment_belongs_to_current_signed_in_user()
     {
         $user = User::factory()->create()->syncRoles('admin');

--- a/tests/Unit/Policies/IncidentPolicyTest.php
+++ b/tests/Unit/Policies/IncidentPolicyTest.php
@@ -447,7 +447,7 @@ class IncidentPolicyTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function test_user_can_comment_on_own_incident()
+    public function test_user_cant_comment_on_incidents()
     {
         $user = User::factory()->create([
             'name' => 'User',
@@ -459,7 +459,7 @@ class IncidentPolicyTest extends TestCase
         ]);
 
         $result = $this->getPolicy()->addComment($user, $incident);
-        $this->assertTrue($result);
+        $this->assertFalse($result);
     }
 
     public function test_supervisor_cant_comment_on_incident_not_assigned_to_them()

--- a/tests/Unit/StoreableEvents/Comment/CommentCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Comment/CommentCreatedTest.php
@@ -13,15 +13,45 @@ use Tests\TestCase;
 
 class CommentCreatedTest extends TestCase
 {
+    public function test_supervisor_comment_does_not_sent_notification_to_self()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function ($user) {
+            $user->syncRoles('admin');
+        });
+
+        $commenter = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create();
+
+        Notification::assertNothingSent();
+
+        $event = new CommentCreated(
+            content: "comments",
+            type: CommentType::NOTE,
+            commentable_id: $incident->id,
+            commentable_type: get_class($incident),
+        );
+
+        $event->setMetaData(['user_id' => $commenter->id]);
+
+        $event->react();
+
+        Notification::assertCount(3);
+        Notification::assertSentTo($admins, CommentAdded::class);
+        Notification::assertNotSentTo($commenter, CommentAdded::class);
+    }
+
     public function test_admin_comment_does_not_send_notification_to_self()
     {
         Notification::fake();
+
         $admins = User::factory(3)->create()->each(function ($user) {
             $user->syncRoles('admin');
         });
 
         $commenter = User::factory()->create()->syncRoles('admin');
-
 
         $incident = Incident::factory()->create();
 

--- a/tests/Unit/StoreableEvents/Comment/CommentCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Comment/CommentCreatedTest.php
@@ -13,6 +13,34 @@ use Tests\TestCase;
 
 class CommentCreatedTest extends TestCase
 {
+    public function test_admin_comment_does_not_send_notification_to_self()
+    {
+        Notification::fake();
+        $admins = User::factory()->create(3)->each(function ($user) {
+            $user->syncRoles('admin');
+        });
+
+        $commenter = User::factory()->create()->syncRoles('admin');
+
+        $incident = Incident::factory()->create();
+
+        Notification::assertNothingSent();
+
+        $event = new CommentCreated(
+            content: "comments",
+            type: CommentType::NOTE,
+            commentable_id: $incident->id,
+            commentable_type: get_class($incident),
+        );
+
+        $event->react();
+
+        Notification::assertCount(3);
+//        Notification::assertSentTo($admins, CommentAdded::class);
+//        Notification::assertNotSentTo($commenter, CommentAdded::class);
+    }
+
+
     public function test_adds_comment_to_model()
     {
         $user = User::factory()->create();

--- a/tests/Unit/StoreableEvents/Comment/CommentCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Comment/CommentCreatedTest.php
@@ -16,11 +16,12 @@ class CommentCreatedTest extends TestCase
     public function test_admin_comment_does_not_send_notification_to_self()
     {
         Notification::fake();
-        $admins = User::factory()->create(3)->each(function ($user) {
+        $admins = User::factory(3)->create()->each(function ($user) {
             $user->syncRoles('admin');
         });
 
         $commenter = User::factory()->create()->syncRoles('admin');
+
 
         $incident = Incident::factory()->create();
 
@@ -33,11 +34,13 @@ class CommentCreatedTest extends TestCase
             commentable_type: get_class($incident),
         );
 
+        $event->setMetaData(['user_id' => $commenter->id]);
+
         $event->react();
 
         Notification::assertCount(3);
-//        Notification::assertSentTo($admins, CommentAdded::class);
-//        Notification::assertNotSentTo($commenter, CommentAdded::class);
+        Notification::assertSentTo($admins, CommentAdded::class);
+        Notification::assertNotSentTo($commenter, CommentAdded::class);
     }
 
 


### PR DESCRIPTION
# Bug Fix

## Summary

- Fixes comment notification sending notification to commenter

## Issue Link
- Fixes #250
- Fixes #251  

## Root Cause Analysis

- Not filtering out commenter user id from comment notification
- No permission existed for comments

## Changes

- Updated comment added event
- Added permission for adding comments on Admin and Supervisor.
- Added check for new permission in comment policy

## Impact

- Roles and perms migration updated. Run fresh migrate on merge

## Testing Strategy

- Added/updated comment added event test

## Regression Risk

NA

## Checklist

- [x] The fix has been locally tested

- [x] New unit tests have been added to prevent future regressions

- [x] The documentation has been updated if necessary

## Additional Notes
NA