### PR TITLE
Fixes confirmation modal z-index

### DIFF
--- a/resources/js/Components/ConfirmationModal/ConfirmationModal.tsx
+++ b/resources/js/Components/ConfirmationModal/ConfirmationModal.tsx
@@ -3,7 +3,6 @@ import PrimaryButton from '@/Components/PrimaryButton';
 import DangerButton from '@/Components/DangerButton';
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react';
 import { ExclamationTriangleIcon } from '@heroicons/react/16/solid';
-import ReactDOM from 'react-dom';
 
 export interface ConfirmationModalProps {
     title: string;
@@ -29,7 +28,7 @@ export default function ConfirmationModal({
 
     const handleNo = () => setShow(false);
 
-    return ReactDOM.createPortal(
+    return (
         <Dialog open={show} onClose={() => {}} className="relative z-50">
             <DialogBackdrop
                 transition
@@ -70,7 +69,6 @@ export default function ConfirmationModal({
                     </DialogPanel>
                 </div>
             </div>
-        </Dialog>,
-        document.body
+        </Dialog>
     );
 }

--- a/resources/js/Components/ConfirmationModal/ConfirmationModal.tsx
+++ b/resources/js/Components/ConfirmationModal/ConfirmationModal.tsx
@@ -3,6 +3,7 @@ import PrimaryButton from '@/Components/PrimaryButton';
 import DangerButton from '@/Components/DangerButton';
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react';
 import { ExclamationTriangleIcon } from '@heroicons/react/16/solid';
+import ReactDOM from 'react-dom';
 
 export interface ConfirmationModalProps {
     title: string;
@@ -28,14 +29,14 @@ export default function ConfirmationModal({
 
     const handleNo = () => setShow(false);
 
-    return (
-        <Dialog open={show} onClose={() => {}} className="relative z-10">
+    return ReactDOM.createPortal(
+        <Dialog open={show} onClose={() => {}} className="relative z-50">
             <DialogBackdrop
                 transition
                 className="fixed inset-0 bg-gray-500/75 transition-opacity data-[closed]:opacity-0 data-[enter]:duration-300 data-[leave]:duration-200 data-[enter]:ease-out data-[leave]:ease-in"
             />
 
-            <div ref={modalRef} className="fixed inset-0 z-10 w-screen overflow-y-auto">
+            <div ref={modalRef} className="fixed inset-0 z-50 w-screen overflow-y-auto">
                 <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
                     <DialogPanel
                         transition
@@ -69,6 +70,7 @@ export default function ConfirmationModal({
                     </DialogPanel>
                 </div>
             </div>
-        </Dialog>
+        </Dialog>,
+        document.body
     );
 }


### PR DESCRIPTION
# Bug Fix

## Summary

Notification menu was overlapping confirmation modal when screen shrunk

## Issue Link

Fixes #255 

## Root Cause Analysis

Confirmation modal had z-100 which is not a tailwind class

## Changes

Changed confirmation modal to use z-50, the highest predefined z-index class.

## Impact

No other component that displays a confirmation modal should have a z-index >= 50

## Testing Strategy

1. Have multiple notifications
2. Open notification menu
3. Clear all
4. Shrink screen until confirmation modal overlaps notification menu

![image](https://github.com/user-attachments/assets/695ad0b2-5c2e-46d4-9e8a-39bb3e00942e)


## Regression Risk

NA

## Checklist

- [x] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes

NA