### PR TITLE
Fixes no null check on user causing crash 

### DIFF
--- a/resources/js/Components/TextInput.tsx
+++ b/resources/js/Components/TextInput.tsx
@@ -21,7 +21,7 @@ export default forwardRef(function TextInput(
             {...props}
             type={type}
             className={
-                'focus:outline-upei-green-600 block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 sm:text-sm/6 ' +
+                'focus:outline-upei-green-600 block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 disabled:text-gray-600 sm:text-sm/6 ' +
                 className
             }
             ref={localRef}

--- a/resources/js/Pages/Incident/Stages/AffectedPartyStage.tsx
+++ b/resources/js/Pages/Incident/Stages/AffectedPartyStage.tsx
@@ -27,18 +27,16 @@ export default function AffectedPartyStage({ formData, setFormData, failedStep, 
     }, [auth.user?.name, formData.first_name, formData.last_name]);
 
     useEffect(() => {
-        if (auth.user && !formData.on_behalf) {
-            setFormData('email', auth.user.email);
-        }
-
         const [firstName, lastName] = getNames();
-
-        setFormData('first_name', firstName);
-        setFormData('last_name', lastName);
-        setFormData('phone', auth.user?.phone ?? formData.phone);
-        setFormData('email', auth.user?.email ?? formData.email);
-        setFormData('upei_id', auth.user?.upei_id ?? formData.upei_id);
-    }, [formData.on_behalf, auth.user, formData.anonymous, setFormData, getNames, formData.phone, formData.email, formData.upei_id]);
+        if (auth.user && !formData.on_behalf) {
+            setFormData('first_name', firstName);
+            setFormData('last_name', lastName);
+            setFormData('phone', auth.user.phone);
+            setFormData('email', auth.user.email);
+            setFormData('upei_id', auth.user.upei_id);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [formData.on_behalf]);
 
     const handleValidStep = () => {
         if (!formData.anonymous && !formData.on_behalf) {
@@ -48,6 +46,14 @@ export default function AffectedPartyStage({ formData, setFormData, failedStep, 
         } else {
             setValidStep(true);
         }
+    };
+
+    const resetAffectedPartyInformation = () => {
+        setFormData('first_name', '');
+        setFormData('last_name', '');
+        setFormData('phone', '');
+        setFormData('email', '');
+        setFormData('upei_id', '');
     };
 
     function checkForm() {
@@ -66,9 +72,12 @@ export default function AffectedPartyStage({ formData, setFormData, failedStep, 
                         onChange={(e) => {
                             setFormData('on_behalf', e.valueOf());
 
-                            if (!e.valueOf()) {
+                            if (e.valueOf()) {
+                                resetAffectedPartyInformation();
+                            } else {
                                 setFormData('email', formData.reporters_email);
                             }
+
                             handleValidStep();
                         }}
                     />
@@ -87,10 +96,8 @@ export default function AffectedPartyStage({ formData, setFormData, failedStep, 
                             <ToggleSwitch
                                 checked={formData.on_behalf_anonymous}
                                 onChange={(e) => {
-                                    if (!e.valueOf) {
-                                        setFormData('email', '');
-                                    }
                                     setFormData('on_behalf_anonymous', e.valueOf());
+                                    resetAffectedPartyInformation();
                                     handleValidStep();
                                 }}
                             />

--- a/resources/js/Pages/Incident/Stages/AffectedPartyStage.tsx
+++ b/resources/js/Pages/Incident/Stages/AffectedPartyStage.tsx
@@ -15,33 +15,30 @@ export default function AffectedPartyStage({ formData, setFormData, failedStep, 
     });
 
     const getNames = useCallback(() => {
-        const names = auth.user.name.split(' ');
+        const names = auth.user?.name.split(' ');
+
+        if (!names) {
+            return [formData.first_name, formData.last_name];
+        }
+
         const firstName = names.length > 1 ? names[0] : auth.user.name;
         const lastName = names.length > 1 ? names[names.length - 1] : '.';
         return [firstName, lastName];
-    }, [auth.user.name]);
+    }, [auth.user?.name, formData.first_name, formData.last_name]);
 
     useEffect(() => {
         if (auth.user && !formData.on_behalf) {
             setFormData('email', auth.user.email);
         }
 
-        if (!formData.anonymous && !formData.on_behalf && auth.user) {
-            const [firstName, lastName] = getNames();
+        const [firstName, lastName] = getNames();
 
-            setFormData('first_name', firstName);
-            setFormData('last_name', lastName);
-            setFormData('phone', auth.user.phone ?? '');
-            setFormData('email', auth.user.email ?? '');
-            setFormData('upei_id', auth.user.upei_id);
-        } else {
-            setFormData('first_name', '');
-            setFormData('last_name', '');
-            setFormData('email', '');
-            setFormData('phone', '');
-            setFormData('upei_id', '');
-        }
-    }, [formData.on_behalf, auth.user, formData.anonymous, setFormData, getNames]);
+        setFormData('first_name', firstName);
+        setFormData('last_name', lastName);
+        setFormData('phone', auth.user?.phone ?? formData.phone);
+        setFormData('email', auth.user?.email ?? formData.email);
+        setFormData('upei_id', auth.user?.upei_id ?? formData.upei_id);
+    }, [formData.on_behalf, auth.user, formData.anonymous, setFormData, getNames, formData.phone, formData.email, formData.upei_id]);
 
     const handleValidStep = () => {
         if (!formData.anonymous && !formData.on_behalf) {


### PR DESCRIPTION
# Bug Fix

## Summary

- Fixes no null check on user causing crash
- Fixes affected party information resetting when navigating back to affected party stage 

## Issue Link

Fixes #266 

## Root Cause Analysis

- Not checking if user is undefined in some areas
- Setting all values to empty strings if no user

## Changes

- Updated AffectedPartyInformation

## Impact
NA

## Testing Strategy

Submit the form as signed out user

## Regression Risk

NA

## Checklist

- [x] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [x] The documentation has been updated if necessary

## Additional Notes

NA