### PR TITLE
Added Activity Log to Investigation Show and RCA Show

### DIFF
--- a/app/Http/Controllers/Investigation/InvestigationController.php
+++ b/app/Http/Controllers/Investigation/InvestigationController.php
@@ -48,7 +48,7 @@ class InvestigationController extends Controller
     {
         $this->authorize('view', $investigation);
 
-        return Inertia::render('Investigation/Show', ['investigation' => $investigation->load(['incident', 'supervisor'])]);
+        return Inertia::render('Investigation/Show', ['investigation' => $investigation->load(['incident.comments.user', 'supervisor'])]);
     }
 
     /**

--- a/app/Http/Controllers/RootCauseAnalysis/RootCauseAnalysisController.php
+++ b/app/Http/Controllers/RootCauseAnalysis/RootCauseAnalysisController.php
@@ -46,7 +46,7 @@ class RootCauseAnalysisController extends Controller
         $this->authorize('view', $rootCauseAnalysis);
 
         return Inertia::render('RootCauseAnalysis/Show', [
-            'rca' => $rootCauseAnalysis->load(['incident', 'supervisor'])
+            'rca' => $rootCauseAnalysis->load(['incident.comments.user','supervisor'])
         ]);
     }
 

--- a/resources/js/Pages/Incident/Partials/ShowComponents/ActivityLog.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/ActivityLog.tsx
@@ -5,40 +5,44 @@ import ActionComment from '@/Pages/Incident/Partials/ShowComponents/ActivityLogC
 import NoteComment from '@/Pages/Incident/Partials/ShowComponents/ActivityLogComponents/CommentComponents/NoteComment';
 import { Comment } from '@/types/Comment';
 import { FormEvent, useEffect, useRef } from 'react';
+import {useForm} from "@inertiajs/react";
+import {Incident} from "@/types/incident/Incident";
 
 interface ActivityLogProps {
-    comments: Comment[];
-    addComment: (e: FormEvent<HTMLFormElement>) => void;
-    setData: ((data: { content: string }) => void) &
-        ((
-            data: (previousData: { content: string }) => {
-                content: string;
-            },
-        ) => void) &
-        (<K extends keyof { content: string }>(key: K, value: { content: string }[K]) => void);
-    processing: boolean;
-    data: { content: string };
+  incident: Incident
 }
 
-export default function ActivityLog({ comments, addComment, setData, processing, data }: ActivityLogProps) {
+export default function ActivityLog({ incident}: ActivityLogProps) {
+    const { data, setData, post, processing, reset } = useForm({
+        content: '',
+    });
+
+    function addComment(e: FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        post(route('incidents.comments.store', { incident: incident.slug }), {
+            preserveScroll: true,
+            onSuccess: () => reset(),
+        });
+    }
+
     const commentFormRef = useRef<HTMLUListElement>(null);
 
     useEffect(() => {
         if (commentFormRef.current) {
             commentFormRef.current.scrollTop = commentFormRef.current.scrollHeight;
         }
-    }, [comments]);
+    }, [incident.comments]);
 
     return (
         <>
             <div className="rounded-lg bg-white p-5 shadow-xs ring-1 ring-gray-900/5 lg:col-start-3">
                 <h2 className="text-sm/6 font-semibold text-gray-900">Activity</h2>
                 <ul ref={commentFormRef} role="list" className="mt-6 max-h-[55rem] space-y-6 overflow-y-scroll">
-                    {comments.map((comment, index) => (
+                    {incident.comments.map((comment, index) => (
                         <li key={index} className="relative flex gap-x-4">
                             <div
                                 className={classNames(
-                                    index === comments.length - 1 ? 'h-6' : '-bottom-6',
+                                    index === incident.comments.length - 1 ? 'h-6' : '-bottom-6',
                                     'absolute top-0 left-0 flex w-6 justify-center',
                                 )}
                             >

--- a/resources/js/Pages/Incident/Show.tsx
+++ b/resources/js/Pages/Incident/Show.tsx
@@ -21,17 +21,7 @@ interface ShowProps extends PageProps {
 export default function Show({ auth, incident, supervisors, roles, canRequestReview, canProvideFollowup }: PageProps<ShowProps>) {
     const user = auth.user;
 
-    const { data, setData, post, processing, reset } = useForm({
-        content: '',
-    });
 
-    function addComment(e: FormEvent<HTMLFormElement>) {
-        e.preventDefault();
-        post(route('incidents.comments.store', { incident: incident.slug }), {
-            preserveScroll: true,
-            onSuccess: () => reset(),
-        });
-    }
 
     useEffect(() => {
         // Refresh incidents prop (if exists) when browser back navigation occurs.
@@ -69,11 +59,7 @@ export default function Show({ auth, incident, supervisors, roles, canRequestRev
 
                             {user.roles.some((role) => role.name === 'admin' || role.name === 'supervisor') && (
                                 <ActivityLog
-                                    data={data}
-                                    setData={setData}
-                                    processing={processing}
-                                    comments={incident.comments}
-                                    addComment={addComment}
+                                   incident={incident}
                                 />
                             )}
                         </div>

--- a/resources/js/Pages/Investigation/Show.tsx
+++ b/resources/js/Pages/Investigation/Show.tsx
@@ -5,6 +5,7 @@ import InvestigationInformationPanel from '@/Pages/Investigation/Partials/ShowCo
 import { PageProps } from '@/types';
 import { Investigation } from '@/types/investigation/Investigation';
 import { Head, usePage } from '@inertiajs/react';
+import ActivityLog from "@/Pages/Incident/Partials/ShowComponents/ActivityLog";
 
 interface ShowProps extends PageProps {
     investigation: Investigation;
@@ -27,6 +28,11 @@ export default function Show({ investigation }: PageProps<ShowProps>) {
                             {user.roles.some((role) => role.name === 'admin') && <InvestigationAdminActions investigation={investigation} />}
 
                             <InvestigationInformationPanel investigation={investigation} />
+                            {user.roles.some((role) => role.name === 'admin' || role.name === 'supervisor') && (
+                                <ActivityLog
+                                    incident={investigation.incident}
+                                />
+                            )}
                         </div>
                     </div>
                 </main>

--- a/resources/js/Pages/RootCauseAnalysis/Show.tsx
+++ b/resources/js/Pages/RootCauseAnalysis/Show.tsx
@@ -5,6 +5,7 @@ import RootCauseAnalysisInformationPanel from '@/Pages/RootCauseAnalysis/Partial
 import { Incident } from '@/types/incident/Incident';
 import { RootCauseAnalysis } from '@/types/rootCauseAnalysis/RootCauseAnalysis';
 import { Head, usePage } from '@inertiajs/react';
+import ActivityLog from "@/Pages/Incident/Partials/ShowComponents/ActivityLog";
 
 export default function Show({ rca }: { rca: RootCauseAnalysis; incident: Incident }) {
     const { user } = usePage().props.auth;
@@ -22,6 +23,11 @@ export default function Show({ rca }: { rca: RootCauseAnalysis; incident: Incide
                     >
                         {user.roles.some((role) => role.name === 'admin') && <RootCauseAnalysisAdminActions rca={rca} />}
                         <RootCauseAnalysisInformationPanel rca={rca} />
+                        {user.roles.some((role) => role.name === 'admin' || role.name === 'supervisor') && (
+                            <ActivityLog
+                                incident={rca.incident}
+                            />
+                        )}
                     </div>
                 </div>
             </main>

--- a/tests/Feature/Investigation/ShowTest.php
+++ b/tests/Feature/Investigation/ShowTest.php
@@ -10,6 +10,29 @@ use Tests\TestCase;
 
 class ShowTest extends TestCase
 {
+    public function test_investigation_has_comments_loaded(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Admin',
+            'email' => 'admin@b.com',
+        ])->syncRoles('admin');
+
+        $this->actingAs($user);
+
+        $incident = Incident::factory()->create();
+        $investigation = Investigation::factory()->create(['incident_id' => $incident->id]);
+
+        $response = $this->get(route('incidents.investigations.show', ['incident' => $incident, 'investigation' => $investigation]));
+
+        $response->assertOk();
+
+        $response->assertInertia(function (AssertableInertia $page) use ($investigation) {
+            return $page->component('Investigation/Show')
+                ->has('investigation')
+                ->where('investigation.id', $investigation->id)
+                ->has('investigation.incident.comments');
+        });
+    }
     public function test_admin_can_view_investigation_show_page()
     {
         $admin = User::factory()->create()->syncRoles('admin');

--- a/tests/Feature/RootCauseAnalysis/ShowTest.php
+++ b/tests/Feature/RootCauseAnalysis/ShowTest.php
@@ -10,6 +10,29 @@ use Tests\TestCase;
 
 class ShowTest extends TestCase
 {
+    public function test_rca_has_comments_loaded(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Admin',
+            'email' => 'admin@b.com',
+        ])->syncRoles('admin');
+
+        $this->actingAs($user);
+
+        $incident = Incident::factory()->create();
+        $rca = RootCauseAnalysis::factory()->create(['incident_id' => $incident->id]);
+
+        $response = $this->get(route('incidents.root-cause-analyses.show', ['incident' => $incident, 'root_cause_analysis' => $rca]));
+
+        $response->assertOk();
+
+        $response->assertInertia(function (AssertableInertia $page) use ($rca) {
+            return $page->component('RootCauseAnalysis/Show')
+                ->has('rca')
+                ->where('rca.id', $rca->id)
+                ->has('rca.incident.comments');
+        });
+    }
     public function test_admin_can_view_rca_show_page()
     {
         $admin = User::factory()->create()->syncRoles('admin');


### PR DESCRIPTION
# Feature Addition [CLOSES #235]

## Summary

Add Activity Log to Investigation Show and RCA Show

## Rationale

Client wanted to see activity log in mentioned pages

## Design Documentation

NA

## Changes

- Added activity log to RCA show page
- Added activity log to investigation show page

## Impact

NA

## Testing

Made tests for features

## Screenshots/Video

![image](https://github.com/user-attachments/assets/aed11d2b-be36-439a-a195-343ca2f68678)
![image](https://github.com/user-attachments/assets/c5e92f06-3ee3-405a-9280-71e95721078c)


## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

NA