### PR TITLE
Notification on Incident Closed

### DIFF
--- a/app/Notifications/Incident/IncidentClosedNotification.php
+++ b/app/Notifications/Incident/IncidentClosedNotification.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Notifications\Incident;
+
+use App\Notifications\BaseNotification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class IncidentClosedNotification extends BaseNotification
+{
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $incidentId,
+    ) {
+        $this->message = "The incident {$incidentId} has been closed";
+        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Incident Closed')
+            ->line($this->message)
+            ->markdown('mail.incident-closed-notification', ['url' => $this->url]);
+    }
+}

--- a/app/StorableEvents/Incident/IncidentClosed.php
+++ b/app/StorableEvents/Incident/IncidentClosed.php
@@ -5,8 +5,11 @@ namespace App\StorableEvents\Incident;
 use App\Enum\CommentType;
 use App\Models\Comment;
 use App\Models\Incident;
+use App\Models\User;
+use App\Notifications\Incident\IncidentClosedNotification;
 use App\States\IncidentStatus\Closed;
 use App\StorableEvents\StoredEvent;
+use Illuminate\Support\Facades\Notification;
 
 class IncidentClosed extends StoredEvent
 {
@@ -25,5 +28,17 @@ class IncidentClosed extends StoredEvent
         $comment->commentable()->associate($incident);
 
         $comment->save();
+    }
+
+    public function react()
+    {
+        $incident = Incident::find($this->aggregateRootUuid());
+
+        if ($incident->supervisor) {
+            Notification::send($incident->supervisor, new IncidentClosedNotification($incident->id));
+        }
+
+        $admins = User::role('admin')->get();
+        Notification::send($admins, new IncidentClosedNotification($incident->id));
     }
 }

--- a/resources/views/mail/incident-closed-notification.blade.php
+++ b/resources/views/mail/incident-closed-notification.blade.php
@@ -4,7 +4,7 @@
 The following incident has been closed.
 
 <x-mail::button :url="$url">
-    View Incident
+View Incident
 </x-mail::button>
 
 Best regards,<br>

--- a/resources/views/mail/incident-closed-notification.blade.php
+++ b/resources/views/mail/incident-closed-notification.blade.php
@@ -1,0 +1,12 @@
+<x-mail::message>
+# Incident Closed
+
+The following incident has been closed.
+
+<x-mail::button :url="$url">
+    View Incident
+</x-mail::button>
+
+Best regards,
+UPEI Health, Safety, and Environment
+</x-mail::message>

--- a/resources/views/mail/incident-closed-notification.blade.php
+++ b/resources/views/mail/incident-closed-notification.blade.php
@@ -7,6 +7,6 @@ The following incident has been closed.
     View Incident
 </x-mail::button>
 
-Best regards,
+Best regards,<br>
 UPEI Health, Safety, and Environment
 </x-mail::message>

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -14,6 +14,7 @@ use App\Models\Investigation;
 use App\Models\User;
 use App\Notifications\Comment\CommentAdded;
 use App\Notifications\Incident\AdditionalInformationNotification;
+use App\Notifications\Incident\IncidentClosedNotification;
 use App\Notifications\Incident\IncidentReviewRequestNotification;
 use App\Notifications\Incident\IncidentSubmittedNotification;
 use App\Notifications\Investigation\InvestigationReturnedNotification;
@@ -1143,5 +1144,66 @@ class IncidentAggregateRootTest extends TestCase
 
         Notification::assertSentTo($supervisor, CommentAdded::class);
         Notification::assertSentTo($admins, CommentAdded::class);
+    }
+
+    public function test_close_incident_notifies_supervisor_when_set()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => InReview::class,
+        ]);
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->closeIncident()
+            ->persist();
+
+        Notification::assertSentTo($supervisor, IncidentClosedNotification::class);
+        Notification::assertSentTo($admins, IncidentClosedNotification::class);
+    }
+
+    public function test_close_incident_does_not_notify_supervisor_when_not_set()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => null,
+            'status' => InReview::class,
+        ]);
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->closeIncident()
+            ->persist();
+
+        Notification::assertNotSentTo($supervisor, IncidentClosedNotification::class);
+        Notification::assertSentTo($admins, IncidentClosedNotification::class);
+    }
+
+    public function test_close_incident_notifies_admin_team()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+
+        $incident = Incident::factory()->create(['status' => InReview::class,]);
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->closeIncident()
+            ->persist();
+
+        Notification::assertSentTo($admins, IncidentClosedNotification::class);
     }
 }

--- a/tests/Unit/StoreableEvents/Incident/IncidentClosedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentClosedTest.php
@@ -5,9 +5,11 @@ namespace Tests\Unit\StoreableEvents\Incident;
 use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\User;
+use App\Notifications\Incident\IncidentClosedNotification;
 use App\States\IncidentStatus\Closed;
 use App\States\IncidentStatus\InReview;
 use App\StorableEvents\Incident\IncidentClosed;
+use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class IncidentClosedTest extends TestCase
@@ -55,5 +57,76 @@ class IncidentClosedTest extends TestCase
         $this->assertEquals($supervisor->id, $incident->supervisor_id);
 
         $this->assertEquals(Closed::class, $incident->status::class);
+    }
+
+    public function test_close_incident_notifies_supervisor()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => InReview::class,
+        ]);
+        $incident->save();
+
+        $event = new IncidentClosed;
+        $event->setAggregateRootUuid($incident->id);
+
+        Notification::assertNothingSent();
+
+        $event->react();
+
+        Notification::assertSentTo($supervisor, IncidentClosedNotification::class);
+        Notification::assertSentTo($admins, IncidentClosedNotification::class);
+    }
+
+    public function test_close_incident_does_not_notify_supervisor_when_supervisor_is_not_set()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => null,
+            'status' => InReview::class,
+        ]);
+        $incident->save();
+
+        $event = new IncidentClosed;
+        $event->setAggregateRootUuid($incident->id);
+
+        Notification::assertNothingSent();
+
+        $event->react();
+
+        Notification::assertNotSentTo($supervisor, IncidentClosedNotification::class);
+        Notification::assertSentTo($admins, IncidentClosedNotification::class);
+    }
+
+    public function test_close_incident_notifies_admin_team()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+
+        $incident = Incident::factory()->create(['status' => InReview::class,]);
+        $incident->save();
+
+        $event = new IncidentClosed;
+        $event->setAggregateRootUuid($incident->id);
+
+        Notification::assertNothingSent();
+
+        $event->react();
+
+        Notification::assertSentTo($admins, IncidentClosedNotification::class);
     }
 }


### PR DESCRIPTION
CLOSES #212

# Feature Addition

## Summary

Now sends a notification to admins and supervisor (if assigned) a mail and database notification when incidents are closed.

## Rationale

Admins and assigned supervisors will be notified when incidents are closed to ensure everyone is informed.

## Design Documentation

Link to any design documents or diagrams relevant to this feature.

## Changes

Adds a react() to IncidentClosed.php.

## Impact

IncidentClosed.php now sends appropriate notifications.

## Testing

* The following tests have been added to IncidentClosedTest.php:
    * test_close_incident_notifies_supervisor
    * test_close_incident_does_not_notify_supervisor_when_supervisor_is_not_set
    * test_close_incident_notifies_admin_team
* The following tests have been added to IncidentAggregateRootTest.php:
    * test_close_incident_notifies_supervisor_when_set
    * test_close_incident_does_not_notify_supervisor_when_not_set
    * test_close_incident_notifies_admin_team

All tests mentioned above are passing.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/cd1dd9f0-d39c-4d5e-89c0-c8dd86beeb2f)

## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

N/A
