### PR TITLE
Fixes no gap on topbar icons for small screens

### DIFF
--- a/resources/js/Layouts/Partials/TopBar.tsx
+++ b/resources/js/Layouts/Partials/TopBar.tsx
@@ -43,7 +43,7 @@ export default function TopBar({ onClick }: { onClick: () => void }) {
                 {/* Separator */}
                 <div aria-hidden="true" className="h-6 w-px bg-gray-900/10 lg:hidden" />
 
-                <div className="flex flex-1 items-center justify-end self-stretch lg:gap-x-6">
+                <div className="flex flex-1 items-center justify-end gap-x-4 self-stretch lg:gap-x-6">
                     {user.roles.some((role) => role.name === 'admin') && (
                         <button type="button" className="cursor-pointer text-gray-400 hover:text-gray-500" onClick={() => setIsSearchOpen(true)}>
                             <MagnifyingGlassIcon aria-hidden="true" className="pointer-events-none col-start-1 row-start-1 size-5 self-center" />


### PR DESCRIPTION
# Bug Fix

## Summary

Fixes no gap on topbar icons for small screens

## Issue Link
Closes #273 

## Root Cause Analysis
No gap-x on small screen

## Changes
Added gap-x-4 for small screens on icon container

## Impact
NA

## Testing Strategy

Shrink screen, see gap between icons

![image](https://github.com/user-attachments/assets/b80257d1-a0c9-4285-923b-be3aed4b46e6)


## Regression Risk
NA

## Checklist

- [x] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes

NA