### PR TITLE
Fixes supervisors getting 403 on incident followup create forms

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -6,6 +6,7 @@ use App\Models\Incident;
 use App\Models\User;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\Closed;
+use App\States\IncidentStatus\Returned;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Spatie\Permission\Models\Role;
@@ -63,7 +64,9 @@ class DashboardController extends Controller
             ->where('supervisor_id', $user->id)
             ->count();
 
-        $unresolvedCount = $incidentCount - $closedCount;
+        $unresolvedCount = Incident::whereState('status', [Assigned::class, Returned::class])
+            ->where('supervisor_id', $user->id)
+            ->count();
 
         return inertia('Dashboard/SupervisorOverview', [
             'unresolvedIncidents' => $unresolvedIncidents,

--- a/app/Policies/InvestigationPolicy.php
+++ b/app/Policies/InvestigationPolicy.php
@@ -6,6 +6,7 @@ use App\Models\Incident;
 use App\Models\Investigation;
 use App\Models\User;
 use App\States\IncidentStatus\Assigned;
+use App\States\IncidentStatus\Returned;
 
 class InvestigationPolicy
 {
@@ -38,11 +39,14 @@ class InvestigationPolicy
      */
     public function create(User $user, Incident $incident): bool
     {
-        if ($user->can('provide incident follow-up') && $incident->supervisor_id == $user->id && $incident->status::class == Assigned::class) {
-            return true;
-        }
-
-        return false;
+        return (
+            $user->can('provide incident follow-up')
+            && $incident->supervisor_id == $user->id
+            && (
+                $incident->status::class == Assigned::class
+                || $incident->status::class == Returned::class
+            )
+        );
     }
 
     /**

--- a/app/Policies/RootCauseAnalysisPolicy.php
+++ b/app/Policies/RootCauseAnalysisPolicy.php
@@ -6,6 +6,7 @@ use App\Models\Incident;
 use App\Models\RootCauseAnalysis;
 use App\Models\User;
 use App\States\IncidentStatus\Assigned;
+use App\States\IncidentStatus\Returned;
 
 class RootCauseAnalysisPolicy
 {
@@ -38,11 +39,14 @@ class RootCauseAnalysisPolicy
      */
     public function create(User $user, Incident $incident): bool
     {
-        if ($user->can('provide incident follow-up') && $incident->supervisor_id == $user->id && $incident->status::class == Assigned::class) {
-            return true;
-        }
-
-        return false;
+        return (
+            $user->can('provide incident follow-up')
+            && $incident->supervisor_id == $user->id
+            && (
+                $incident->status::class == Assigned::class
+                || $incident->status::class == Returned::class
+            )
+        );
     }
 
     /**

--- a/resources/js/Pages/Dashboard/SupervisorOverview.tsx
+++ b/resources/js/Pages/Dashboard/SupervisorOverview.tsx
@@ -35,7 +35,10 @@ export default function SupervisorOverview({ unresolvedIncidents, incidentCount,
                                     JSON.stringify([
                                         {
                                             column: 'status',
-                                            values: [{ value: IncidentStatus.ASSIGNED, comparator: '=' }],
+                                            values: [
+                                                { value: IncidentStatus.ASSIGNED, comparator: '=' },
+                                                { value: IncidentStatus.RETURNED, comparator: '=' },
+                                            ],
                                         },
                                     ]),
                                 ),

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -6,6 +6,7 @@ use App\Models\Incident;
 use App\Models\User;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\Closed;
+use App\States\IncidentStatus\Returned;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
@@ -244,7 +245,8 @@ class DashboardTest extends TestCase
         $supervisor = User::factory()->create()->syncRoles('supervisor');
         $this->actingAs($supervisor);
 
-        Incident::factory(10)->create(['supervisor_id' => $supervisor->id]);
+        Incident::factory(10)->create(['supervisor_id' => $supervisor->id, 'status' => Assigned::class]);
+        Incident::factory(10)->create(['supervisor_id' => $supervisor->id, 'status' => Returned::class]);
         Incident::factory(10)->create(['supervisor_id' => $supervisor->id, 'status' => Closed::class]);
         Incident::factory(10)->create();
 
@@ -255,8 +257,8 @@ class DashboardTest extends TestCase
 
         $response->assertInertia(function (AssertableInertia $page) {
             $page->component('Dashboard/SupervisorOverview')
-                ->has('closedCount')
-                ->where('closedCount', 10);
+                ->has('unresolvedCount')
+                ->where('unresolvedCount', 20);
         });
     }
 

--- a/tests/Feature/Investigation/CreateTest.php
+++ b/tests/Feature/Investigation/CreateTest.php
@@ -5,12 +5,32 @@ namespace Tests\Feature\Investigation;
 use App\Models\Incident;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\InReview;
+use App\States\IncidentStatus\Returned;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 use App\Models\User;
 
 class CreateTest extends TestCase
 {
+    public function test_supervisor_can_view_investigation_create_form_when_in_returned_state()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Returned::class
+        ]);
+
+        $response = $this->actingAs($supervisor)->get(route('incidents.investigations.create', ['incident' => $incident->id]));
+
+        $response->assertStatus(200);
+
+        $response->assertInertia(function (AssertableInertia $page) use ($incident) {
+            return $page->component('Investigation/Create')
+                ->where('incident.id', $incident->id);
+        });
+    }
+
     public function test_forbidden_if_not_assigned_state(): void
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');

--- a/tests/Feature/RootCauseAnalysis/CreateTest.php
+++ b/tests/Feature/RootCauseAnalysis/CreateTest.php
@@ -5,11 +5,29 @@ namespace Tests\Feature\RootCauseAnalysis;
 use App\Models\Incident;
 use App\Models\User;
 use App\States\IncidentStatus\Assigned;
+use App\States\IncidentStatus\Returned;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
 class CreateTest extends TestCase
 {
+    public function test_supervisor_can_view_rca_create_in_returned_state()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $this->actingAs($supervisor);
+
+        $incident = Incident::factory()->create(['supervisor_id' => $supervisor->id, 'status' => Returned::class]);
+
+        $response = $this->get(route('incidents.root-cause-analyses.create', ['incident' => $incident->id]));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (AssertableInertia $page) =>
+        $page->component('RootCauseAnalysis/Create')
+            ->has('incident')
+            ->where('incident.id', $incident->id));
+    }
+
     public function test_assigned_supervisor_can_view_rca_create_form()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');

--- a/tests/Unit/Policies/InvestigationPolicyTest.php
+++ b/tests/Unit/Policies/InvestigationPolicyTest.php
@@ -8,10 +8,22 @@ use App\Models\User;
 use App\Policies\InvestigationPolicy;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\InReview;
+use App\States\IncidentStatus\Returned;
 use Tests\TestCase;
 
 class InvestigationPolicyTest extends TestCase
 {
+    public function test_supervisor_can_create_investigation_in_returned_state()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Returned::class
+        ]);
+
+        $this->assertTrue($this->getPolicy()->create($supervisor, $incident));
+    }
+
     public function test_supervisor_can_not_create_investigation_if_assigned_to_someone_else()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');

--- a/tests/Unit/Policies/RootCauseAnalysisPolicyTest.php
+++ b/tests/Unit/Policies/RootCauseAnalysisPolicyTest.php
@@ -8,10 +8,22 @@ use App\Models\Incident;
 use App\Policies\RootCauseAnalysisPolicy;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\InReview;
+use App\States\IncidentStatus\Returned;
 use Tests\TestCase;
 
 class RootCauseAnalysisPolicyTest extends TestCase
 {
+    public function test_superisor_can_create_rca_when_in_returned_state()
+    {
+        $supervisor = User::factory()->create()->assignRole('supervisor');
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Returned::class
+        ]);
+
+        $this->assertTrue($this->getPolicy()->create($supervisor, $incident));
+    }
+
     public function test_admin_can_view_any_rca()
     {
         $admin = User::factory()->create()->syncRoles('admin');


### PR DESCRIPTION
# Bug Fix

## Summary

Fixes supervisors getting 403 on incident followup create forms

## Issue Link

Fixes #277 
Fixes #279 

## Root Cause Analysis

- Not checking for returned state in create policies
- Not checking returned status on unresolved count for supervisor overview
- Not filtering by returned when clicking on unresolved incidents in supervisor overview 

## Changes

Added check for returned state for create methods in investigation and rca policies, dashboard controller, and link to unresolved incidents

## Impact
NA

## Testing Strategy

- Go to returned incident as supervisor
- Click on buttons to go to create form for rca or investigation

- Go to supervisor overview
- See correct number of unresolved incidents that are assigned or returned
- See correct filters when clicking on unresolved incidents link

## Regression Risk
NA

## Checklist

- [x] The fix has been locally tested

- [x] New unit tests have been added to prevent future regressions

- [x] The documentation has been updated if necessary

## Additional Notes
NA