### PR TITLE
Fixes activity log taking up 2/3 of screen for supervisors

### DIFF
--- a/resources/js/Pages/Investigation/Show.tsx
+++ b/resources/js/Pages/Investigation/Show.tsx
@@ -22,9 +22,7 @@ export default function Show({ investigation }: PageProps<ShowProps>) {
                             {user.roles.some((role) => role.name === 'admin') && <InvestigationAdminActions investigation={investigation} />}
 
                             <InvestigationInformationPanel investigation={investigation} />
-                            {user.roles.some((role) => role.name === 'admin' || role.name === 'supervisor') && (
-                                <ActivityLog incident={investigation.incident} />
-                            )}
+                            <ActivityLog incident={investigation.incident} />
                         </div>
                     </div>
                 </main>

--- a/resources/js/Pages/Investigation/Show.tsx
+++ b/resources/js/Pages/Investigation/Show.tsx
@@ -1,11 +1,10 @@
-import classNames from '@/Filters/classNames';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import ActivityLog from '@/Pages/Incident/Partials/ShowComponents/ActivityLog';
 import InvestigationAdminActions from '@/Pages/Investigation/Partials/ShowComponents/InvestigationAdminActions';
 import InvestigationInformationPanel from '@/Pages/Investigation/Partials/ShowComponents/InvestigationInformationPanel';
 import { PageProps } from '@/types';
 import { Investigation } from '@/types/investigation/Investigation';
 import { Head, usePage } from '@inertiajs/react';
-import ActivityLog from "@/Pages/Incident/Partials/ShowComponents/ActivityLog";
 
 interface ShowProps extends PageProps {
     investigation: Investigation;
@@ -19,19 +18,12 @@ export default function Show({ investigation }: PageProps<ShowProps>) {
             <>
                 <main>
                     <div className="mx-auto px-4 py-10 sm:px-6 lg:px-8">
-                        <div
-                            className={classNames(
-                                'mx-auto grid max-w-2xl grid-cols-1 grid-rows-1 items-start gap-x-8 gap-y-8 lg:mx-0 lg:max-w-none',
-                                user.roles.some(({ name }) => name === 'supervisor') ? 'lg:grid-cols-1' : 'lg:grid-cols-3',
-                            )}
-                        >
+                        <div className="mx-auto grid max-w-2xl grid-cols-1 grid-rows-1 items-start gap-x-8 gap-y-8 lg:mx-0 lg:max-w-none lg:grid-cols-3">
                             {user.roles.some((role) => role.name === 'admin') && <InvestigationAdminActions investigation={investigation} />}
 
                             <InvestigationInformationPanel investigation={investigation} />
                             {user.roles.some((role) => role.name === 'admin' || role.name === 'supervisor') && (
-                                <ActivityLog
-                                    incident={investigation.incident}
-                                />
+                                <ActivityLog incident={investigation.incident} />
                             )}
                         </div>
                     </div>

--- a/resources/js/Pages/RootCauseAnalysis/Show.tsx
+++ b/resources/js/Pages/RootCauseAnalysis/Show.tsx
@@ -17,7 +17,7 @@ export default function Show({ rca }: { rca: RootCauseAnalysis; incident: Incide
                     <div className="mx-auto grid max-w-2xl grid-cols-1 grid-rows-1 items-start gap-x-8 gap-y-8 lg:mx-0 lg:max-w-none lg:grid-cols-3">
                         {user.roles.some((role) => role.name === 'admin') && <RootCauseAnalysisAdminActions rca={rca} />}
                         <RootCauseAnalysisInformationPanel rca={rca} />
-                        {user.roles.some((role) => role.name === 'admin' || role.name === 'supervisor') && <ActivityLog incident={rca.incident} />}
+                        <ActivityLog incident={rca.incident} />
                     </div>
                 </div>
             </main>

--- a/resources/js/Pages/RootCauseAnalysis/Show.tsx
+++ b/resources/js/Pages/RootCauseAnalysis/Show.tsx
@@ -1,11 +1,10 @@
-import classNames from '@/Filters/classNames';
 import Authenticated from '@/Layouts/AuthenticatedLayout';
+import ActivityLog from '@/Pages/Incident/Partials/ShowComponents/ActivityLog';
 import RootCauseAnalysisAdminActions from '@/Pages/RootCauseAnalysis/Partials/ShowComponents/RootCauseAnalysisAdminActions';
 import RootCauseAnalysisInformationPanel from '@/Pages/RootCauseAnalysis/Partials/ShowComponents/RootCauseAnalysisInformationPanel';
 import { Incident } from '@/types/incident/Incident';
 import { RootCauseAnalysis } from '@/types/rootCauseAnalysis/RootCauseAnalysis';
 import { Head, usePage } from '@inertiajs/react';
-import ActivityLog from "@/Pages/Incident/Partials/ShowComponents/ActivityLog";
 
 export default function Show({ rca }: { rca: RootCauseAnalysis; incident: Incident }) {
     const { user } = usePage().props.auth;
@@ -15,19 +14,10 @@ export default function Show({ rca }: { rca: RootCauseAnalysis; incident: Incide
             <Head title="Root Cause Analysis" />
             <main>
                 <div className="mx-auto px-4 py-10 sm:px-6 lg:px-8">
-                    <div
-                        className={classNames(
-                            'mx-auto grid max-w-2xl grid-cols-1 grid-rows-1 items-start gap-x-8 gap-y-8 lg:mx-0 lg:max-w-none',
-                            user.roles.some(({ name }) => name === 'supervisor') ? 'lg:grid-cols-1' : 'lg:grid-cols-3',
-                        )}
-                    >
+                    <div className="mx-auto grid max-w-2xl grid-cols-1 grid-rows-1 items-start gap-x-8 gap-y-8 lg:mx-0 lg:max-w-none lg:grid-cols-3">
                         {user.roles.some((role) => role.name === 'admin') && <RootCauseAnalysisAdminActions rca={rca} />}
                         <RootCauseAnalysisInformationPanel rca={rca} />
-                        {user.roles.some((role) => role.name === 'admin' || role.name === 'supervisor') && (
-                            <ActivityLog
-                                incident={rca.incident}
-                            />
-                        )}
+                        {user.roles.some((role) => role.name === 'admin' || role.name === 'supervisor') && <ActivityLog incident={rca.incident} />}
                     </div>
                 </div>
             </main>


### PR DESCRIPTION
# Bug Fix

## Summary

Fixes activity log taking up 2/3 of screen for supervisors

## Issue Link

Fixes #280 

## Root Cause Analysis

Grid layout of container being 1 column for supervisors since there were no other panels before we added the activity log to the RCA and Investigation

## Changes

Removed check for supervisor role in container and made it always a 3 col grid.

## Impact

NA

## Testing Strategy
Go to RCA and Investigation as supervisor and see correct layout

## Regression Risk
NA

## Checklist

- [x] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes

NA