### PR TITLE
Fixes supervisor actions showing for own incidents

### DIFF
--- a/resources/js/Pages/Incident/Show.tsx
+++ b/resources/js/Pages/Incident/Show.tsx
@@ -7,8 +7,8 @@ import IncidentSupervisorActions from '@/Pages/Incident/Partials/ShowComponents/
 import IncidentUserActions from '@/Pages/Incident/Partials/ShowComponents/IncidentUserActions';
 import { PageProps, Role, User } from '@/types';
 import { Incident } from '@/types/incident/Incident';
-import { Head, router, useForm } from '@inertiajs/react';
-import { FormEvent, useEffect } from 'react';
+import { Head, router } from '@inertiajs/react';
+import { useEffect } from 'react';
 
 interface ShowProps extends PageProps {
     incident: Incident;
@@ -20,8 +20,6 @@ interface ShowProps extends PageProps {
 
 export default function Show({ auth, incident, supervisors, roles, canRequestReview, canProvideFollowup }: PageProps<ShowProps>) {
     const user = auth.user;
-
-
 
     useEffect(() => {
         // Refresh incidents prop (if exists) when browser back navigation occurs.
@@ -46,7 +44,7 @@ export default function Show({ auth, incident, supervisors, roles, canRequestRev
                             {user.roles.some((role) => role.name === 'admin') && (
                                 <IncidentAdminActions incident={incident} supervisors={supervisors} roles={roles}></IncidentAdminActions>
                             )}
-                            {user.roles.some((role) => role.name === 'supervisor') && (
+                            {user.roles.some((role) => role.name === 'supervisor') && user.email !== incident.reporters_email && (
                                 <IncidentSupervisorActions
                                     incident={incident}
                                     canRequestReview={canRequestReview}
@@ -57,11 +55,7 @@ export default function Show({ auth, incident, supervisors, roles, canRequestRev
 
                             <IncidentInformationPanel incident={incident} />
 
-                            {user.roles.some((role) => role.name === 'admin' || role.name === 'supervisor') && (
-                                <ActivityLog
-                                   incident={incident}
-                                />
-                            )}
+                            {user.roles.some((role) => role.name === 'admin' || role.name === 'supervisor') && <ActivityLog incident={incident} />}
                         </div>
                     </div>
                 </main>


### PR DESCRIPTION
# Bug Fix

## Summary

Fixes supervisor actions showing for own incidents

## Issue Link

Fixes #282 

## Root Cause Analysis

Not checking if own incident on Supervisor Actions conditional render

## Changes

Adds check for own incident

## Impact

NA

## Testing Strategy

Submit incident as supervisor, view incident, see no supervisor actions

## Regression Risk

NA

## Checklist

- [x] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes

Any further information needed to understand the fix or its impact.