### PR TITLE
Notification on Incident Reopened

### DIFF
--- a/app/Notifications/Incident/IncidentReopenedNotification.php
+++ b/app/Notifications/Incident/IncidentReopenedNotification.php
@@ -45,6 +45,9 @@ class IncidentReopenedNotification extends BaseNotification
         return (new MailMessage)
             ->subject('Incident Reopened')
             ->line($this->message)
-            ->markdown('mail.incident-reopened-notification', ['url' => $this->url]);
+            ->markdown('mail.incident-reopened-notification', [
+                'url' => $this->url,
+                'message' => $this->message,
+                ]);
     }
 }

--- a/app/Notifications/Incident/IncidentReopenedNotification.php
+++ b/app/Notifications/Incident/IncidentReopenedNotification.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Notifications\Incident;
+
+use App\Notifications\BaseNotification;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\VonageMessage;
+
+class IncidentReopenedNotification extends BaseNotification
+{
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public string $incidentId,
+    ) {
+        $this->message = "The incident {$incidentId} has been reopened.";
+        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database', 'vonage'];
+    }
+
+    /**
+     * Get the Vonage / SMS representation of the notification.
+     */
+    public function toVonage(object $notifiable): VonageMessage
+    {
+        return (new VonageMessage)
+            ->content($this->message);
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Incident Reopened')
+            ->line($this->message)
+            ->markdown('mail.incident-reopened-notification', ['url' => $this->url]);
+    }
+}

--- a/app/StorableEvents/Incident/IncidentReopened.php
+++ b/app/StorableEvents/Incident/IncidentReopened.php
@@ -35,6 +35,6 @@ class IncidentReopened extends StoredEvent
     {
         $incident = Incident::find($this->aggregateRootUuid());
         $admins = User::role('admin')->get();
-        Notification::send($admins, new IncidentReopenedNotification($incident->id));
+        Notification::send($admins, new IncidentReopenedNotification($incident->slug));
     }
 }

--- a/app/StorableEvents/Incident/IncidentReopened.php
+++ b/app/StorableEvents/Incident/IncidentReopened.php
@@ -5,8 +5,11 @@ namespace App\StorableEvents\Incident;
 use App\Enum\CommentType;
 use App\Models\Comment;
 use App\Models\Incident;
+use App\Models\User;
+use App\Notifications\Incident\IncidentReopenedNotification;
 use App\States\IncidentStatus\Reopened;
 use App\StorableEvents\StoredEvent;
+use Illuminate\Support\Facades\Notification;
 
 class IncidentReopened extends StoredEvent
 {
@@ -26,5 +29,12 @@ class IncidentReopened extends StoredEvent
         $comment->commentable()->associate($incident);
 
         $comment->save();
+    }
+
+    public function react()
+    {
+        $incident = Incident::find($this->aggregateRootUuid());
+        $admins = User::role('admin')->get();
+        Notification::send($admins, new IncidentReopenedNotification($incident->id));
     }
 }

--- a/resources/views/mail/incident-reopened-notification.blade.php
+++ b/resources/views/mail/incident-reopened-notification.blade.php
@@ -7,6 +7,6 @@ The following incident has been reopened.
 View Incident
 </x-mail::button>
 
-Thanks,<br>
+Best regards,<br>
 UPEI Health, Safety, and Environment
 </x-mail::message>

--- a/resources/views/mail/incident-reopened-notification.blade.php
+++ b/resources/views/mail/incident-reopened-notification.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # Incident Reopened
 
-The following incident has been reopened.
+{{$message}}
 
 <x-mail::button :url="$url">
 View Incident

--- a/resources/views/mail/incident-reopened-notification.blade.php
+++ b/resources/views/mail/incident-reopened-notification.blade.php
@@ -1,0 +1,12 @@
+<x-mail::message>
+# Incident Reopened
+
+The following incident has been reopened.
+
+<x-mail::button :url="$url">
+View Incident
+</x-mail::button>
+
+Thanks,<br>
+UPEI Health, Safety, and Environment
+</x-mail::message>

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -15,6 +15,7 @@ use App\Models\User;
 use App\Notifications\Comment\CommentAdded;
 use App\Notifications\Incident\AdditionalInformationNotification;
 use App\Notifications\Incident\IncidentClosedNotification;
+use App\Notifications\Incident\IncidentReopenedNotification;
 use App\Notifications\Incident\IncidentReviewRequestNotification;
 use App\Notifications\Incident\IncidentSubmittedNotification;
 use App\Notifications\Investigation\InvestigationReturnedNotification;
@@ -1205,5 +1206,30 @@ class IncidentAggregateRootTest extends TestCase
             ->persist();
 
         Notification::assertSentTo($admins, IncidentClosedNotification::class);
+    }
+
+    public function test_reopened_incident_notifies_admins()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $user = User::factory()->create()->syncRoles('user');
+
+        $incident = Incident::factory()->create([
+            'status' => Closed::class,
+            'supervisor_id' => $supervisor->id,
+            ]);
+
+        IncidentAggregateRoot::retrieve($incident->id)
+            ->reopenIncident()
+            ->persist();
+
+        Notification::assertCount(3);
+        Notification::assertSentTo($admins, IncidentReopenedNotification::class);
+        Notification::assertNotSentTo($supervisor, IncidentReopenedNotification::class);
+        Notification::assertNotSentTo($user, IncidentReopenedNotification::class);
     }
 }

--- a/tests/Unit/StoreableEvents/Incident/IncidentReopenedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReopenedTest.php
@@ -5,10 +5,12 @@ namespace Tests\Unit\StoreableEvents\Incident;
 use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\User;
+use App\Notifications\Incident\IncidentReopenedNotification;
 use App\States\IncidentStatus\Closed;
 use App\States\IncidentStatus\Opened;
 use App\States\IncidentStatus\Reopened;
 use App\StorableEvents\Incident\IncidentReopened;
+use Illuminate\Support\Facades\Notification;
 use Spatie\ModelStates\Exceptions\TransitionNotFound;
 use Tests\TestCase;
 
@@ -73,5 +75,33 @@ class IncidentReopenedTest extends TestCase
         $incident->refresh();
         $this->assertNull($incident->supervisor_id);
         $this->assertEquals(Reopened::class, $incident->status::class);
+    }
+
+    public function test_reopen_incident_notifies_admin_team()
+    {
+        Notification::fake();
+
+        $admins = User::factory(3)->create()->each(function (User $user) {
+            $user->syncRoles('admin');
+        });
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $user = User::factory()->create()->syncRoles('user');
+
+        $incident = Incident::factory()->create([
+            'status' => Closed::class,
+            'supervisor_id' => $supervisor->id,
+            ]);
+
+        $event = new IncidentReopened;
+        $event->setAggregateRootUuid($incident->id);
+
+        Notification::assertNothingSent();
+
+        $event->react();
+
+        Notification::assertCount(3);
+        Notification::assertSentTo($admins, IncidentReopenedNotification::class);
+        Notification::assertNotSentTo($supervisor, IncidentReopenedNotification::class);
+        Notification::assertNotSentTo($user, IncidentReopenedNotification::class);
     }
 }


### PR DESCRIPTION
# Feature Addition

CLOSES #213

## Summary

Sends an email, database, and SMS notification to all admins when an incident is reopened.

## Rationale

This will alert admins when an incident has been reopened so that immediate action can take place to ensure all issues are taken care of in a timely manner.

## Design Documentation

N/A

## Changes

Changes IncidentReopened.php to have a react() method that sends a notification to all admins.

## Impact

N/A

## Testing

The following test has been added to IncidentReopenedTest.php:
* test_reopen_incident_notifies_admin_team()

This following test has been added to IncidentAggregateRootTest.php:
* test_reopened_incident_notifies_admins()

All tests mentioned above are passing.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/61112fd5-ed07-43fd-807b-660459923266)

## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

The two tests created for this feature does test to make sure that nobody with the "user" or "supervisor" roles will be notified; the test only passes if only the admins are notified.
