### PR TITLE
Adds incident slug to all applicable notifications

### DIFF
--- a/app/Notifications/Comment/CommentAdded.php
+++ b/app/Notifications/Comment/CommentAdded.php
@@ -17,9 +17,10 @@ class CommentAdded extends BaseNotification
     public function __construct(
         public string $comment,
         public User $user,
-        public string $url
+        public string $url,
+        public string $incidentSlug,
     ) {
-        $this->message = "{$this->user->name} commented: $this->comment";
+        $this->message = "$user->name commented on incident #$incidentSlug: $comment";
     }
 
     /**
@@ -31,8 +32,10 @@ class CommentAdded extends BaseNotification
             ->subject('Comment Created')
             ->line($this->message)
             ->markdown('mail.comment-made', [
+                'incidentSlug' => $this->incidentSlug,
                 'commenter' => $this->user->name,
                 'content' => $this->comment,
+                'url' => $this->url,
             ]);
     }
 }

--- a/app/Notifications/Incident/AdditionalInformationNotification.php
+++ b/app/Notifications/Incident/AdditionalInformationNotification.php
@@ -7,10 +7,10 @@ use Illuminate\Notifications\Messages\MailMessage;
 
 class AdditionalInformationNotification extends BaseNotification
 {
-    public function __construct(public string $incidentId, public string $additionalInformation)
+    public function __construct(public string $incidentSlug, public string $additionalInformation)
     {
-        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
-        $this->message = 'Additional information was added to an incident';
+        $this->url = route('incidents.show', ['incident' => $this->incidentSlug]);
+        $this->message = "Additional information was added to incident# $this->incidentSlug";
     }
 
     /**
@@ -19,9 +19,10 @@ class AdditionalInformationNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Incident Additional Information Added')
+            ->subject("Additional Information Added To Incident #$this->incidentSlug")
             ->markdown('mail.incident-additional-information', [
                 'url' => $this->url,
+                'incidentSlug' => $this->incidentSlug,
                 'additionalInformation' => $this->additionalInformation,
             ]);
     }

--- a/app/Notifications/Incident/FilesUploadedNotification.php
+++ b/app/Notifications/Incident/FilesUploadedNotification.php
@@ -12,11 +12,11 @@ class FilesUploadedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentId,
+        public string $incidentSlug,
         public User   $user
     ) {
-        $this->message = "{$this->user->name} has uploaded files to the following incident.";
-        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
+        $this->message = "{$this->user->name} has uploaded files to incident #$incidentSlug.";
+        $this->url = route('incidents.show', ['incident' => $incidentSlug]);
     }
 
     /**
@@ -35,7 +35,7 @@ class FilesUploadedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Files Have Been Added to Incident')
-            ->markdown('mail.files-uploaded-notification', ['url' => $this->url]);
+            ->subject("Files Have Been Uploaded to Incident #$this->incidentSlug")
+            ->markdown('mail.files-uploaded-notification', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Incident/IncidentClosedNotification.php
+++ b/app/Notifications/Incident/IncidentClosedNotification.php
@@ -33,7 +33,7 @@ class IncidentClosedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Incident Closed')
+            ->subject("Incident #$this->incidentSlug Closed")
             ->markdown('mail.incident-closed-notification', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Incident/IncidentClosedNotification.php
+++ b/app/Notifications/Incident/IncidentClosedNotification.php
@@ -11,10 +11,10 @@ class IncidentClosedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentId,
+        public string $incidentSlug,
     ) {
-        $this->message = "The incident {$incidentId} has been closed";
-        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
+        $this->message = "Incident #$incidentSlug has been closed";
+        $this->url = route('incidents.show', ['incident' => $this->incidentSlug]);
     }
 
     /**
@@ -34,7 +34,6 @@ class IncidentClosedNotification extends BaseNotification
     {
         return (new MailMessage)
             ->subject('Incident Closed')
-            ->line($this->message)
-            ->markdown('mail.incident-closed-notification', ['url' => $this->url]);
+            ->markdown('mail.incident-closed-notification', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Incident/IncidentFollowUpOverdueNotification.php
+++ b/app/Notifications/Incident/IncidentFollowUpOverdueNotification.php
@@ -44,8 +44,7 @@ class IncidentFollowUpOverdueNotification extends BaseNotification
      */
     public function shouldSend(object $notifiable, string $channel): bool
     {
-        $incident = Incident::find($this->incidentSlug);
-
+        $incident = Incident::where('slug', $this->incidentSlug)->first();
         return ($incident->status::class == Assigned::class || $incident->status::class == Returned::class)
             && $incident->supervisor_id == $this->supervisor->id;
     }

--- a/app/Notifications/Incident/IncidentFollowUpOverdueNotification.php
+++ b/app/Notifications/Incident/IncidentFollowUpOverdueNotification.php
@@ -56,7 +56,7 @@ class IncidentFollowUpOverdueNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Follow Up Overdue')
+            ->subject("Incident #$this->incidentSlug Follow Up Overdue")
             ->markdown('mail.incident-follow-up-overdue-notification', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Incident/IncidentFollowUpOverdueNotification.php
+++ b/app/Notifications/Incident/IncidentFollowUpOverdueNotification.php
@@ -19,11 +19,11 @@ class IncidentFollowUpOverdueNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentId,
-        public User $supervisor,
+        public string $incidentSlug,
+        public User   $supervisor,
     ) {
-        $this->message = "Your required follow up is overdue.";
-        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
+        $this->message = "Your required follow-up on incident #$incidentSlug is overdue.";
+        $this->url = route('incidents.show', ['incident' => $incidentSlug]);
     }
 
     /**
@@ -44,7 +44,7 @@ class IncidentFollowUpOverdueNotification extends BaseNotification
      */
     public function shouldSend(object $notifiable, string $channel): bool
     {
-        $incident = Incident::find($this->incidentId);
+        $incident = Incident::find($this->incidentSlug);
 
         return ($incident->status::class == Assigned::class || $incident->status::class == Returned::class)
             && $incident->supervisor_id == $this->supervisor->id;
@@ -57,6 +57,6 @@ class IncidentFollowUpOverdueNotification extends BaseNotification
     {
         return (new MailMessage)
             ->subject('Follow Up Overdue')
-            ->markdown('mail.incident-follow-up-overdue-notification', ['url' => $this->url]);
+            ->markdown('mail.incident-follow-up-overdue-notification', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Incident/IncidentReopenedNotification.php
+++ b/app/Notifications/Incident/IncidentReopenedNotification.php
@@ -12,10 +12,10 @@ class IncidentReopenedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentId,
+        public string $incidentSlug,
     ) {
-        $this->message = "The incident {$incidentId} has been reopened.";
-        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
+        $this->message = "Incident #{$incidentSlug} has been reopened.";
+        $this->url = route('incidents.show', ['incident' => $incidentSlug]);
     }
 
     /**

--- a/app/Notifications/Incident/IncidentReopenedNotification.php
+++ b/app/Notifications/Incident/IncidentReopenedNotification.php
@@ -43,7 +43,7 @@ class IncidentReopenedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Incident Reopened')
+            ->subject("Incident $this->incidentSlug Reopened")
             ->line($this->message)
             ->markdown('mail.incident-reopened-notification', [
                 'url' => $this->url,

--- a/app/Notifications/Incident/IncidentReviewRequestNotification.php
+++ b/app/Notifications/Incident/IncidentReviewRequestNotification.php
@@ -12,11 +12,11 @@ class IncidentReviewRequestNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentId,
-        public User $supervisor,
+        public string $incidentSlug,
+        public User   $supervisor,
     ) {
-        $this->message = "{$this->supervisor->name} has requested an incident follow up review.";
-        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
+        $this->message = "{$this->supervisor->name} has requested follow-up review on incident #$incidentSlug.";
+        $this->url = route('incidents.show', ['incident' => $incidentSlug]);
     }
 
     /**
@@ -26,6 +26,6 @@ class IncidentReviewRequestNotification extends BaseNotification
     {
         return (new MailMessage)
             ->subject('Incident Follow Up Review Request')
-            ->markdown('mail.incident-review-request', ['url' => $this->url]);
+            ->markdown('mail.incident-review-request', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Incident/IncidentReviewRequestNotification.php
+++ b/app/Notifications/Incident/IncidentReviewRequestNotification.php
@@ -25,7 +25,7 @@ class IncidentReviewRequestNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Incident Follow Up Review Request')
+            ->subject("Incident #$this->incidentSlug Follow Up Review Request")
             ->markdown('mail.incident-review-request', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Incident/IncidentSubmittedNotification.php
+++ b/app/Notifications/Incident/IncidentSubmittedNotification.php
@@ -56,7 +56,7 @@ class IncidentSubmittedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Incident Submitted')
+            ->subject("Incident #$this->incidentSlug Submitted")
             ->markdown('mail.incident-submitted', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Incident/IncidentSubmittedNotification.php
+++ b/app/Notifications/Incident/IncidentSubmittedNotification.php
@@ -12,22 +12,22 @@ class IncidentSubmittedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentId,
+        public string  $incidentSlug,
         public ?string $firstName,
         public ?string $lastName,
     ) {
-        if ($this->firstName == null && $this->lastName == null) {
+        if ($firstName == null && $lastName == null) {
             $name = 'an Anonymous User';
-        } elseif ($this->firstName == null) {
-            $name = $this->lastName;
-        } elseif ($this->lastName == null) {
-            $name = $this->firstName;
+        } elseif ($firstName == null) {
+            $name = $lastName;
+        } elseif ($lastName == null) {
+            $name = $firstName;
         } else {
-            $name = $this->firstName.' '.$this->lastName;
+            $name = $firstName . ' ' . $lastName;
         }
-        $this->message = "An incident was submitted by $name";
+        $this->message = "Incident #$incidentSlug was submitted by $name";
         $this->url = route('incidents.show', [
-            'incident' => $this->incidentId,
+            'incident' => $incidentSlug,
         ]);
     }
 
@@ -57,6 +57,6 @@ class IncidentSubmittedNotification extends BaseNotification
     {
         return (new MailMessage)
             ->subject('Incident Submitted')
-            ->markdown('mail.incident-submitted', ['url' => $this->url]);
+            ->markdown('mail.incident-submitted', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Incident/IncidentSubmittedNotification.php
+++ b/app/Notifications/Incident/IncidentSubmittedNotification.php
@@ -12,7 +12,7 @@ class IncidentSubmittedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string  $incidentSlug,
+        public string  $incidentId,
         public ?string $firstName,
         public ?string $lastName,
     ) {
@@ -25,9 +25,9 @@ class IncidentSubmittedNotification extends BaseNotification
         } else {
             $name = $firstName . ' ' . $lastName;
         }
-        $this->message = "Incident #$incidentSlug was submitted by $name";
+        $this->message = "An incident was submitted by $name";
         $this->url = route('incidents.show', [
-            'incident' => $incidentSlug,
+            'incident' => $incidentId,
         ]);
     }
 
@@ -56,7 +56,7 @@ class IncidentSubmittedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Incident #$this->incidentSlug Submitted")
+            ->subject("Incident Submitted")
             ->markdown('mail.incident-submitted', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Incident/SupervisorAssignedNotification.php
+++ b/app/Notifications/Incident/SupervisorAssignedNotification.php
@@ -26,7 +26,7 @@ class SupervisorAssignedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Incident Assigned')
+            ->subject("Incident #$this->incidentSlug Assigned")
             ->markdown('mail.incident-assigned', [
                 'url' => $this->url,
                 'supervisorName' => $this->supervisor->name,

--- a/app/Notifications/Incident/SupervisorAssignedNotification.php
+++ b/app/Notifications/Incident/SupervisorAssignedNotification.php
@@ -12,12 +12,12 @@ class SupervisorAssignedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentId,
-        public User $supervisor,
-        public User $admin,
+        public string $incidentSlug,
+        public User   $supervisor,
+        public User   $admin,
     ) {
-        $this->url = route('incidents.show', ['incident' => $this->incidentId]);
-        $this->message = "$admin->name has assigned you to a new Incident";
+        $this->url = route('incidents.show', ['incident' => $incidentSlug]);
+        $this->message = "$admin->name has assigned you to incident #$incidentSlug.";
     }
 
     /**
@@ -30,7 +30,8 @@ class SupervisorAssignedNotification extends BaseNotification
             ->markdown('mail.incident-assigned', [
                 'url' => $this->url,
                 'supervisorName' => $this->supervisor->name,
-                'adminName' => $this->admin->name
+                'adminName' => $this->admin->name,
+                'incidentSlug' => $this->incidentSlug,
             ]);
     }
 }

--- a/app/Notifications/Investigation/InvestigationReturnedNotification.php
+++ b/app/Notifications/Investigation/InvestigationReturnedNotification.php
@@ -12,14 +12,14 @@ class InvestigationReturnedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentId,
+        public string $incidentSlug,
         public string $investigationId,
-        public User $admin
+        public User   $admin
     ) {
-        $this->message = "$admin->name has returned your investigation for further review";
+        $this->message = "$admin->name has returned your investigation on incident #$incidentSlug for further review";
         $this->url = route('incidents.investigations.show', [
-            'incident' => $this->incidentId,
-            'investigation' => $this->investigationId
+            'incident' => $incidentSlug,
+            'investigation' => $investigationId
         ]);
     }
 

--- a/app/Notifications/Investigation/InvestigationReturnedNotification.php
+++ b/app/Notifications/Investigation/InvestigationReturnedNotification.php
@@ -29,7 +29,7 @@ class InvestigationReturnedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Investigation Returned')
+            ->subject("Investigation For Incident #$this->incidentSlug Returned")
             ->markdown('mail.investigation-returned', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Investigation/InvestigationSubmittedNotification.php
+++ b/app/Notifications/Investigation/InvestigationSubmittedNotification.php
@@ -29,7 +29,7 @@ class InvestigationSubmittedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Investigation Submitted')
+            ->subject("Investigation Submitted For Incident #$this->incidentSlug")
             ->markdown('mail.investigation-submitted', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/Investigation/InvestigationSubmittedNotification.php
+++ b/app/Notifications/Investigation/InvestigationSubmittedNotification.php
@@ -12,14 +12,14 @@ class InvestigationSubmittedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentId,
+        public string $incidentSlug,
         public string $investigationId,
-        public User $supervisor,
+        public User   $supervisor,
     ) {
-        $this->message = "A new investigation was submitted by {$this->supervisor->name}";
+        $this->message = "A new investigation for incident #$incidentSlug was submitted by $supervisor->name";
         $this->url = route('incidents.investigations.show', [
-            'incident' => $this->incidentId,
-            'investigation' => $this->investigationId
+            'incident' => $incidentSlug,
+            'investigation' => $investigationId
         ]);
     }
 
@@ -30,6 +30,6 @@ class InvestigationSubmittedNotification extends BaseNotification
     {
         return (new MailMessage)
             ->subject('Investigation Submitted')
-            ->markdown('mail.investigation-submitted', ['url' => $this->url]);
+            ->markdown('mail.investigation-submitted', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
+++ b/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
@@ -12,14 +12,14 @@ class RootCauseAnalysisSubmittedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentId,
+        public string $incidentSlug,
         public string $rootCauseAnalysisId,
-        public User $supervisor,
+        public User   $supervisor,
     ) {
-        $this->message = "A new root cause analysis was submitted by {$this->supervisor->name}";
+        $this->message = "A new root cause analysis for incident #$incidentSlug was submitted by $supervisor->name";
         $this->url = route('incidents.root-cause-analyses.show', [
-            'incident' => $this->incidentId,
-            'root_cause_analysis' => $this->rootCauseAnalysisId
+            'incident' => $incidentSlug,
+            'root_cause_analysis' => $rootCauseAnalysisId
         ]);
 
     }
@@ -31,6 +31,6 @@ class RootCauseAnalysisSubmittedNotification extends BaseNotification
     {
         return (new MailMessage)
             ->subject('Root Cause Analysis Submitted')
-            ->markdown('mail.root-cause-analysis-submitted', ['url' => $this->url]);
+            ->markdown('mail.root-cause-analysis-submitted', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
+++ b/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
@@ -30,7 +30,7 @@ class RootCauseAnalysisSubmittedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Root Cause Analysis Submitted')
+            ->subject("Root Cause Analysis Submitted For Incident #$this->incidentSlug")
             ->markdown('mail.root-cause-analysis-submitted', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/StorableEvents/Comment/CommentCreated.php
+++ b/app/StorableEvents/Comment/CommentCreated.php
@@ -41,7 +41,7 @@ class CommentCreated extends StoredEvent
         if ($commentable) {
             $url = route('incidents.show', ['incident' => $this->commentable_id]);
 
-            $notification = new CommentAdded($this->content, $commenter, $url);
+            $notification = new CommentAdded($this->content, $commenter, $url, $commentable->slug);
 
             if ($commentable->supervisor && $commentable->supervisor->id !== $this->metaData['user_id']) {
                 Notification::send($commentable->supervisor, $notification);

--- a/app/StorableEvents/Incident/AdditionalInformationAdded.php
+++ b/app/StorableEvents/Incident/AdditionalInformationAdded.php
@@ -3,6 +3,7 @@
 namespace App\StorableEvents\Incident;
 
 use App\Enum\CommentType;
+use App\Models\Comment;
 use App\Models\Incident;
 use App\Models\User;
 use App\Notifications\Incident\AdditionalInformationNotification;

--- a/app/StorableEvents/Incident/AdditionalInformationAdded.php
+++ b/app/StorableEvents/Incident/AdditionalInformationAdded.php
@@ -2,6 +2,7 @@
 
 namespace App\StorableEvents\Incident;
 
+use App\Enum\CommentType;
 use App\Models\Incident;
 use App\Models\User;
 use App\Notifications\Incident\AdditionalInformationNotification;
@@ -32,11 +33,23 @@ class AdditionalInformationAdded extends StoredEvent
 
         $incident->additional_information = $additionalInfo;
         $incident->save();
+
+        $comment = new Comment;
+
+        $comment->user_id = $this->metaData['user_id'];
+        $comment->type = CommentType::ACTION;
+        $comment->content = 'Additional information added.';
+
+        $comment->commentable()->associate($incident);
+
+        $comment->save();
     }
 
     public function react()
     {
         $admins = User::role('admin')->get();
-        Notification::send($admins, new AdditionalInformationNotification($this->aggregateRootUuid(), $this->additionalInformation));
+        $incident = Incident::find($this->aggregateRootUuid());
+
+        Notification::send($admins, new AdditionalInformationNotification($incident->slug, $this->additionalInformation));
     }
 }

--- a/app/StorableEvents/Incident/FilesUploaded.php
+++ b/app/StorableEvents/Incident/FilesUploaded.php
@@ -34,9 +34,10 @@ class FilesUploaded extends StoredEvent
     public function react()
     {
         $admins = User::role('admin')->get();
-
         $supervisor = User::find($this->metaData['user_id']);
 
-        Notification::send($admins, new FilesUploadedNotification($this->aggregateRootUuid(), $supervisor));
+        $incident = Incident::find($this->aggregateRootUuid());
+
+        Notification::send($admins, new FilesUploadedNotification($incident->slug, $supervisor));
     }
 }

--- a/app/StorableEvents/Incident/IncidentClosed.php
+++ b/app/StorableEvents/Incident/IncidentClosed.php
@@ -39,6 +39,6 @@ class IncidentClosed extends StoredEvent
         }
 
         $admins = User::role('admin')->get();
-        Notification::send($admins, new IncidentClosedNotification($incident->id));
+        Notification::send($admins, new IncidentClosedNotification($incident->slug));
     }
 }

--- a/app/StorableEvents/Incident/IncidentCreated.php
+++ b/app/StorableEvents/Incident/IncidentCreated.php
@@ -92,8 +92,7 @@ class IncidentCreated extends StoredEvent
         }
 
         $admins = User::role('admin')->get();
-        $incident = Incident::find($this->aggregateRootUuid());
 
-        Notification::send($admins, new IncidentSubmittedNotification($incident->slug, $this->first_name, $this->last_name));
+        Notification::send($admins, new IncidentSubmittedNotification($this->aggregateRootUuid(), $this->first_name, $this->last_name));
     }
 }

--- a/app/StorableEvents/Incident/IncidentCreated.php
+++ b/app/StorableEvents/Incident/IncidentCreated.php
@@ -92,6 +92,8 @@ class IncidentCreated extends StoredEvent
         }
 
         $admins = User::role('admin')->get();
-        Notification::send($admins, new IncidentSubmittedNotification($this->aggregateRootUuid(), $this->first_name, $this->last_name));
+        $incident = Incident::find($this->aggregateRootUuid());
+
+        Notification::send($admins, new IncidentSubmittedNotification($incident->slug, $this->first_name, $this->last_name));
     }
 }

--- a/app/StorableEvents/Incident/IncidentReviewRequested.php
+++ b/app/StorableEvents/Incident/IncidentReviewRequested.php
@@ -39,9 +39,10 @@ class IncidentReviewRequested extends StoredEvent
     public function react()
     {
         $admins = User::role('admin')->get();
-
         $supervisor = User::find($this->metaData['user_id']);
 
-        Notification::send($admins, new IncidentReviewRequestNotification($this->aggregateRootUuid(), $supervisor));
+        $incident = Incident::find($this->aggregateRootUuid());
+
+        Notification::send($admins, new IncidentReviewRequestNotification($incident->slug, $supervisor));
     }
 }

--- a/app/StorableEvents/Incident/SupervisorAssigned.php
+++ b/app/StorableEvents/Incident/SupervisorAssigned.php
@@ -53,9 +53,10 @@ class SupervisorAssigned extends StoredEvent
     public function react()
     {
         $admin = User::find($this->metaData['user_id']);
+        $incident = Incident::find($this->aggregateRootUuid());
 
-        Notification::send($this->supervisor(), new SupervisorAssignedNotification($this->aggregateRootUuid(), $this->supervisor(), $admin));
+        Notification::send($this->supervisor(), new SupervisorAssignedNotification($incident->slug, $this->supervisor(), $admin));
 
-        Notification::send($this->supervisor(), new IncidentFollowUpOverdueNotification($this->aggregateRootUuid(), $this->supervisor()));
+        Notification::send($this->supervisor(), new IncidentFollowUpOverdueNotification($incident->slug, $this->supervisor()));
     }
 }

--- a/resources/js/Layouts/Partials/TopBar.tsx
+++ b/resources/js/Layouts/Partials/TopBar.tsx
@@ -108,7 +108,7 @@ export default function TopBar({ onClick }: { onClick: () => void }) {
 
                         {/* Profile dropdown */}
                         <Menu as="div" className="relative">
-                            <MenuButton className="-m-1.5 flex items-center p-1.5">
+                            <MenuButton className="-m-1.5 flex cursor-pointer items-center p-1.5">
                                 <span className="sr-only">Open user menu</span>
                                 <UserCircleIcon className="size-8 rounded-full bg-gray-50" />
                                 <span className="hidden lg:flex lg:items-center">

--- a/resources/views/mail/comment-made.blade.php
+++ b/resources/views/mail/comment-made.blade.php
@@ -1,8 +1,14 @@
 <x-mail::message>
-    # Comment Created
+# Comment Created
 
-    {{ $commenter }} commented: {{ $content }}
+## {{ $commenter }} has commented the following on incident #{{$incidentSlug}}:
 
-    Best regards,
-    UPEI Health, Safety, and Environment
+{{ $content }}
+
+<x-mail::button :url="$url">
+View Incident
+</x-mail::button>
+
+Best regards,
+UPEI Health, Safety, and Environment
 </x-mail::message>

--- a/resources/views/mail/files-uploaded-notification.blade.php
+++ b/resources/views/mail/files-uploaded-notification.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # Files Uploaded to Incident
 
-Files have been uploaded to the below incident.
+{{$message}}
 
 <x-mail::button :url="$url">
 View Incident

--- a/resources/views/mail/incident-additional-information.blade.php
+++ b/resources/views/mail/incident-additional-information.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # Incident Additional Information Added
 
-## The following incident has had the following information added:
+## Incident #{{$incidentSlug}} has had the following information added:
 
 {{$additionalInformation}}
 

--- a/resources/views/mail/incident-assigned.blade.php
+++ b/resources/views/mail/incident-assigned.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # Incident Assigned
 
-{{$supervisorName}}, you have been assigned to review the following incident by {{$adminName}}.
+{{$supervisorName}}, you have been assigned to review incident #{{$incidentSlug}} by {{$adminName}}.
 
 Please submit an investigation within 24 hours and root cause analysis within 72 hours by visiting the following link:
 

--- a/resources/views/mail/incident-closed-notification.blade.php
+++ b/resources/views/mail/incident-closed-notification.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # Incident Closed
 
-The following incident has been closed.
+{{$message}}
 
 <x-mail::button :url="$url">
 View Incident

--- a/resources/views/mail/incident-follow-up-overdue-notification.blade.php
+++ b/resources/views/mail/incident-follow-up-overdue-notification.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
-# Overdue Follow Up
+# Overdue Follow-Up
 
-Follow-up on the below incident is overdue.
+{{$message}}
 
 <x-mail::button :url="$url">
 View Incident

--- a/resources/views/mail/incident-review-request.blade.php
+++ b/resources/views/mail/incident-review-request.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # Incident Follow Up Review Request
 
-Your review has been requested on the below incident and its follow up.
+{{$message}}
 
 <x-mail::button :url="$url">
 View Incident

--- a/resources/views/mail/incident-submitted.blade.php
+++ b/resources/views/mail/incident-submitted.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # Incident Submitted
 
-A new incident has been submitted.
+{{$message}}
 
 <x-mail::button :url="$url">
 View Incident

--- a/resources/views/mail/investigation-submitted.blade.php
+++ b/resources/views/mail/investigation-submitted.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # Investigation Submitted
 
-An investigation was submitted. Click below to view the investigation that was submitted.
+{{$message}}
 
 <x-mail::button :url="$url">
 View Investigation

--- a/resources/views/mail/root-cause-analysis-submitted.blade.php
+++ b/resources/views/mail/root-cause-analysis-submitted.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # Root Cause Analysis Submitted
 
-A root cause analysis was submitted. Click below to view the root cause analysis that was submitted.
+{{$message}}
 
 <x-mail::button :url="$url">
 View Root Cause Analysis

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,19 +60,19 @@ Route::get('/notification', function () {
     $additionalInfo = new \App\Notifications\Incident\AdditionalInformationNotification($incident->slug, 'Some additional information');
     $filesUploaded = new \App\Notifications\Incident\FilesUploadedNotification($incident->slug, $supervisor);
 
-//    return $filesUploaded->toMail($supervisor);
-//    return $commentMade->toMail($supervisor);
-//    return $incidentClosed->toMail($supervisor);
-//    return $followupOverdue->toMail($supervisor);
-//    return $incidentReopened->toMail($supervisor);
-//    return $incidentFollowupReview->toMail($supervisor);
-//    return $incidentReceived->render();
-//    return $userAdded->render();
-//    return $incidentSubmitted->toMail($supervisor);
-//    return $investigationSubmitted->toMail($supervisor);
-//    return $investigationReturned->toMail($supervisor);
-//    return $incidentAssigned->toMail($supervisor);
-//    return $rcaSubmitted->toMail($supervisor);
+    //    return $filesUploaded->toMail($supervisor);
+    //    return $commentMade->toMail($supervisor);
+    //    return $incidentClosed->toMail($supervisor);
+    //    return $followupOverdue->toMail($supervisor);
+    //    return $incidentReopened->toMail($supervisor);
+    //    return $incidentFollowupReview->toMail($supervisor);
+    //    return $incidentReceived->render();
+    //    return $userAdded->render();
+    //    return $incidentSubmitted->toMail($supervisor);
+    //    return $investigationSubmitted->toMail($supervisor);
+    //    return $investigationReturned->toMail($supervisor);
+    //    return $incidentAssigned->toMail($supervisor);
+    //    return $rcaSubmitted->toMail($supervisor);
     return $additionalInfo->toMail($supervisor);
 
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,7 @@ Route::get('/notification', function () {
     $userAdded = new \App\Mail\UserAdded;
 
     $incidentSubmitted = new \App\Notifications\Incident\IncidentSubmittedNotification(
-        incidentSlug: $incident->slug,
+        incidentId: $incident->slug,
         firstName: null,
         lastName: null,
     );

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,52 +12,68 @@ Route::get('/notification', function () {
     $investigation = \App\Models\Investigation::factory()->create();
     $rca = \App\Models\RootCauseAnalysis::factory()->create();
 
-    $incidentReceived = new \App\Mail\IncidentReceived($incident->id);
+
+    $commentMade = new \App\Notifications\Comment\CommentAdded(
+        comment: "Some comment",
+        user: $supervisor,
+        url: route('incidents.show', ['incident' => $incident->slug]),
+        incidentSlug: $incident->slug,
+    );
+
+    $incidentClosed = new \App\Notifications\Incident\IncidentClosedNotification($incident->slug);
+    $followupOverdue = new \App\Notifications\Incident\IncidentFollowUpOverdueNotification(incidentSlug: $incident->slug, supervisor: $supervisor);
+    $incidentReopened = new \App\Notifications\Incident\IncidentReopenedNotification($incident->slug);
+    $incidentFollowupReview = new \App\Notifications\Incident\IncidentReviewRequestNotification(incidentSlug: $incident->slug, supervisor: $supervisor);
+    $incidentReceived = new \App\Mail\IncidentReceived($incident->slug);
     $userAdded = new \App\Mail\UserAdded;
 
     $incidentSubmitted = new \App\Notifications\Incident\IncidentSubmittedNotification(
-        incidentId: $incident->id,
+        incidentSlug: $incident->slug,
         firstName: null,
         lastName: null,
     );
 
     $incidentAssigned = new \App\Notifications\Incident\SupervisorAssignedNotification(
-        incidentId: $incident->id,
+        incidentSlug: $incident->slug,
         admin: $admin,
         supervisor: $supervisor,
     );
 
     $investigationSubmitted = new \App\Notifications\Investigation\InvestigationSubmittedNotification(
-        incidentId: $incident->id,
+        incidentSlug: $incident->slug,
         investigationId: $investigation->id,
         supervisor: $supervisor,
     );
 
     $investigationReturned = new \App\Notifications\Investigation\InvestigationReturnedNotification(
-        incidentId: $incident->id,
+        incidentSlug: $incident->slug,
         investigationId: $investigation->id,
         admin: $admin
     );
 
     $rcaSubmitted = new \App\Notifications\RootCauseAnalysis\RootCauseAnalysisSubmittedNotification(
-        incidentId: $incident->id,
+        incidentSlug: $incident->slug,
         rootCauseAnalysisId: $rca->id,
         supervisor: $supervisor,
     );
 
-    $additionalInfo = new \App\Notifications\Incident\AdditionalInformationNotification($incident->id, 'Some additional information');
+    $additionalInfo = new \App\Notifications\Incident\AdditionalInformationNotification($incident->slug, 'Some additional information');
+    $filesUploaded = new \App\Notifications\Incident\FilesUploadedNotification($incident->slug, $supervisor);
 
-    $filesUploaded = new \App\Notifications\Incident\FilesUploadedNotification($incident->id, $supervisor);
-
-    // return $incidentReceived->render();
-    // return $userAdded->render();
-    // return $incidentSubmitted->toMail($supervisor);
-    // return $investigationSubmitted->toMail($supervisor);
-    // return $investigationReturned->toMail($supervisor);
-    // return $incidentAssigned->toMail($supervisor);
-    // return $rcaSubmitted->toMail($supervisor);
-    // return $additionalInfo->toMail($supervisor);
-    return $filesUploaded->toMail($supervisor);
+//    return $filesUploaded->toMail($supervisor);
+//    return $commentMade->toMail($supervisor);
+//    return $incidentClosed->toMail($supervisor);
+//    return $followupOverdue->toMail($supervisor);
+//    return $incidentReopened->toMail($supervisor);
+//    return $incidentFollowupReview->toMail($supervisor);
+//    return $incidentReceived->render();
+//    return $userAdded->render();
+//    return $incidentSubmitted->toMail($supervisor);
+//    return $investigationSubmitted->toMail($supervisor);
+//    return $investigationReturned->toMail($supervisor);
+//    return $incidentAssigned->toMail($supervisor);
+//    return $rcaSubmitted->toMail($supervisor);
+    return $additionalInfo->toMail($supervisor);
 
 });
 

--- a/tests/Feature/Incident/AdditionalInformationTest.php
+++ b/tests/Feature/Incident/AdditionalInformationTest.php
@@ -11,6 +11,30 @@ use Tests\TestCase;
 
 class AdditionalInformationTest extends TestCase
 {
+    public function test_additional_information_adds_comment()
+    {
+
+        $user = User::factory()->create([
+            'email' => 'user@b.com'
+        ]);
+        $this->actingAs($user);
+
+        $incident = Incident::factory()->create([
+            'reporters_email' => $user->email,
+        ]);
+
+        $this->assertNull($incident->additional_information);
+        $this->assertDatabaseCount('comments', 0);
+
+        $response = $this->patch(route('incidents.additional-information', $incident), [
+            'additional_information' => 'information'
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseCount('comments', 1);
+    }
+
     public function test_first_additional_information_on_incident_creates_new_array()
     {
         $user = User::factory()->create([

--- a/tests/Feature/Incident/FileTest.php
+++ b/tests/Feature/Incident/FileTest.php
@@ -132,7 +132,7 @@ class FileTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (FilesUploadedNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentSlug === $incident->id && $notification->user->id === $supervisor->id;
+                return $notification->incidentSlug === $incident->slug && $notification->user->id === $supervisor->id;
             }
         );
     }

--- a/tests/Feature/Incident/FileTest.php
+++ b/tests/Feature/Incident/FileTest.php
@@ -132,7 +132,7 @@ class FileTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (FilesUploadedNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentId === $incident->id && $notification->user->id === $supervisor->id;
+                return $notification->incidentSlug === $incident->id && $notification->user->id === $supervisor->id;
             }
         );
     }

--- a/tests/Feature/Incident/FileTest.php
+++ b/tests/Feature/Incident/FileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Incident;
+namespace Tests\Feature\Incident;
 
 use App\Enum\CommentType;
 use App\Models\File;

--- a/tests/Feature/Incident/StatusTest.php
+++ b/tests/Feature/Incident/StatusTest.php
@@ -105,7 +105,7 @@ class StatusTest extends TestCase
         Notification::assertSentTo(
             $supervisor,
             function (InvestigationReturnedNotification $notification, array $channels) use ($incident, $admin) {
-                return $notification->incidentId === $incident->id && $notification->admin->id === $admin->id;
+                return $notification->incidentSlug === $incident->id && $notification->admin->id === $admin->id;
             }
         );
     }
@@ -433,7 +433,7 @@ class StatusTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentId === $incident->id && $notification->supervisor->id === $supervisor->id;
+                return $notification->incidentSlug === $incident->id && $notification->supervisor->id === $supervisor->id;
             }
         );
     }

--- a/tests/Feature/Incident/StatusTest.php
+++ b/tests/Feature/Incident/StatusTest.php
@@ -388,7 +388,7 @@ class StatusTest extends TestCase
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $admins, $supervisor) {
                 $databaseStore = $notification->toArray($admins->first());
 
-                $this->assertEquals(route('incidents.show', $incident->id), $databaseStore['url']);
+                $this->assertEquals(route('incidents.show', $incident->slug), $databaseStore['url']);
 
                 return array_key_exists('message', $databaseStore);
             }
@@ -412,12 +412,12 @@ class StatusTest extends TestCase
             'status' => Assigned::class
         ]);
 
-        $investigation = Investigation::factory()->create([
+        Investigation::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
 
-        $rca = RootCauseAnalysis::factory()->create([
+        RootCauseAnalysis::factory()->create([
             'incident_id' => $incident->id,
             'supervisor_id' => $supervisor->id,
         ]);
@@ -433,7 +433,7 @@ class StatusTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentSlug === $incident->id && $notification->supervisor->id === $supervisor->id;
+                return $notification->incidentSlug === $incident->slug && $notification->supervisor->id === $supervisor->id;
             }
         );
     }

--- a/tests/Feature/Incident/SupervisorTest.php
+++ b/tests/Feature/Incident/SupervisorTest.php
@@ -44,7 +44,7 @@ class SupervisorTest extends TestCase
                 $databaseStore = $notification->toArray($supervisor);
 
                 $this->assertEquals(
-                    route('incidents.show', ['incident' => $incident->id]),
+                    route('incidents.show', ['incident' => $incident->slug]),
                     $databaseStore['url']
                 );
 
@@ -81,7 +81,7 @@ class SupervisorTest extends TestCase
             $supervisor,
             function (SupervisorAssignedNotification $notification, array $channels) use ($incident, $supervisor, $admin) {
                 return (
-                    $notification->incidentSlug === $incident->id &&
+                    $notification->incidentSlug === $incident->slug &&
                     $notification->admin->id === $admin->id &&
                     $notification->supervisor->id == $supervisor->id
                 );

--- a/tests/Feature/Incident/SupervisorTest.php
+++ b/tests/Feature/Incident/SupervisorTest.php
@@ -81,7 +81,7 @@ class SupervisorTest extends TestCase
             $supervisor,
             function (SupervisorAssignedNotification $notification, array $channels) use ($incident, $supervisor, $admin) {
                 return (
-                    $notification->incidentId === $incident->id &&
+                    $notification->incidentSlug === $incident->id &&
                     $notification->admin->id === $admin->id &&
                     $notification->supervisor->id == $supervisor->id
                 );

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -347,7 +347,7 @@ class IncidentAggregateRootTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentId === $incident->id && $notification->supervisor->id === $supervisor->id;
+                return $notification->incidentSlug === $incident->id && $notification->supervisor->id === $supervisor->id;
             }
         );
     }

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -250,7 +250,7 @@ class IncidentAggregateRootTest extends TestCase
             function (AdditionalInformationNotification $notification, array $channels) use ($incident, $admins) {
                 $databaseStore = $notification->toArray($admins->first());
 
-                $this->assertEquals(route('incidents.show', $incident->id), $databaseStore['url']);
+                $this->assertEquals(route('incidents.show', $incident->slug), $databaseStore['url']);
 
                 return array_key_exists('message', $databaseStore);
             }
@@ -312,7 +312,7 @@ class IncidentAggregateRootTest extends TestCase
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $admins, $supervisor) {
                 $databaseStore = $notification->toArray($admins->first());
 
-                $this->assertEquals(route('incidents.show', $incident->id), $databaseStore['url']);
+                $this->assertEquals(route('incidents.show', $incident->slug), $databaseStore['url']);
 
                 return array_key_exists('message', $databaseStore);
             }
@@ -347,7 +347,7 @@ class IncidentAggregateRootTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentSlug === $incident->id && $notification->supervisor->id === $supervisor->id;
+                return $notification->incidentSlug === $incident->slug && $notification->supervisor->id === $supervisor->id;
             }
         );
     }

--- a/tests/Unit/StoreableEvents/Incident/AdditionalInformationAddedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/AdditionalInformationAddedTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\StoreableEvents\Incident;
 
 use App\Models\Incident;
+use App\Models\User;
 use App\StorableEvents\Incident\AdditionalInformationAdded;
 use Illuminate\Support\Carbon;
 use Tests\TestCase;
@@ -11,11 +12,18 @@ class AdditionalInformationAddedTest extends TestCase
 {
     public function test_first_additional_creates_new_array()
     {
-        $incident = Incident::factory()->create();
+        $user = User::factory()->create([
+            'email' => 'user@b.com'
+        ]);
+        $incident = Incident::factory()->create(
+            ['reporters_email' => $user->email]
+        );
 
         $this->assertNull($incident->additional_information);
 
         $event = new AdditionalInformationAdded("information");
+
+        $event->setMetaData(['user_id' => $user->id]);
         $event->setAggregateRootUuid($incident->id);
 
         $event->handle();
@@ -32,7 +40,12 @@ class AdditionalInformationAddedTest extends TestCase
 
     public function test_additional_appends_to_current_additional_information()
     {
+        $user = User::factory()->create([
+            'email' => 'user@b.com'
+        ]);
+
         $incident = Incident::factory()->create([
+            'reporters_email' => $user->email,
             'additional_information' => [
                 ['information' => 'information 1', 'created_at' => now()->timestamp],
             ]
@@ -41,6 +54,8 @@ class AdditionalInformationAddedTest extends TestCase
         $this->assertCount(1, $incident->additional_information);
 
         $event = new AdditionalInformationAdded("information 2");
+
+        $event->setMetaData(['user_id' => $user->id]);
         $event->setAggregateRootUuid($incident->id);
 
         $event->handle();

--- a/tests/Unit/StoreableEvents/Incident/FilesUploadedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/FilesUploadedTest.php
@@ -35,7 +35,7 @@ class FilesUploadedTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (FilesUploadedNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentId === $incident->id && $notification->user->id === $supervisor->id;
+                return $notification->incidentSlug === $incident->id && $notification->user->id === $supervisor->id;
             }
         );
     }

--- a/tests/Unit/StoreableEvents/Incident/FilesUploadedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/FilesUploadedTest.php
@@ -35,7 +35,7 @@ class FilesUploadedTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (FilesUploadedNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentSlug === $incident->id && $notification->user->id === $supervisor->id;
+                return $notification->incidentSlug === $incident->slug && $notification->user->id === $supervisor->id;
             }
         );
     }

--- a/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
@@ -45,7 +45,7 @@ class IncidentReviewRequestedTest extends TestCase
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $admins, $supervisor) {
                 $databaseStore = $notification->toArray($admins->first());
 
-                $this->assertEquals(route('incidents.show', $incident->id), $databaseStore['url']);
+                $this->assertEquals(route('incidents.show', $incident->slug), $databaseStore['url']);
 
                 return array_key_exists('message', $databaseStore);
             }
@@ -79,7 +79,7 @@ class IncidentReviewRequestedTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentSlug === $incident->id && $notification->supervisor->id === $supervisor->id;
+                return $notification->incidentSlug === $incident->slug && $notification->supervisor->id === $supervisor->id;
             }
         );
     }

--- a/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
@@ -79,7 +79,7 @@ class IncidentReviewRequestedTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentId === $incident->id && $notification->supervisor->id === $supervisor->id;
+                return $notification->incidentSlug === $incident->id && $notification->supervisor->id === $supervisor->id;
             }
         );
     }


### PR DESCRIPTION
# Feature Addition [CLOSES #286]

## Summary

Adds incident slug to all applicable notifications

## Rationale

To be able to identify which notification is for which incident.

## Design Documentation

NA

## Changes
Adds incident slug to the following notifications and their respective mail templates:
- CommentAdded
- AdditionalInformation
- FilesUploaded
- IncidentClosed
- IncidentFollowupOverdue
- IncidentReopened
- IncidentReviewRequest
- SupervisorAssigned

## Impact
NA

## Testing

- Updated web.php to test all notifications
- Affected tests updated

## Screenshots/Video

NA

## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

NA
