### PR TITLE
Adds missing information to incident show page

### DIFF
--- a/resources/js/Pages/Incident/Index.tsx
+++ b/resources/js/Pages/Incident/Index.tsx
@@ -254,7 +254,7 @@ export default function Index({ incidents, indexType, currentFilters, currentSor
                                                 >
                                                     <div>
                                                         <span className="sm:block md:hidden">Incident</span>
-                                                        <span className="hidden md:inline-block">Reporter</span>
+                                                        <span className="hidden md:inline-block">Name</span>
                                                     </div>
                                                     <div className="ml-2 rounded-sm text-gray-400 group-hover:visible group-focus:visible">
                                                         <ChevronUpIcon

--- a/resources/js/Pages/Incident/Partials/ShowComponents/IncidentInformationPanel.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/IncidentInformationPanel.tsx
@@ -5,6 +5,7 @@ import AdditionalInformation from '@/Pages/Incident/Partials/ShowComponents/Info
 import AffectedPartyInformation from '@/Pages/Incident/Partials/ShowComponents/InformationComponents/AffectedPartyInformation';
 import GeneralDescription from '@/Pages/Incident/Partials/ShowComponents/InformationComponents/GeneralDescription';
 import IncidentInformation from '@/Pages/Incident/Partials/ShowComponents/InformationComponents/IncidentInformation';
+import ReportingInformation from '@/Pages/Incident/Partials/ShowComponents/InformationComponents/ReportingInformation';
 import SupervisorInformation from '@/Pages/Incident/Partials/ShowComponents/InformationComponents/SupervisorInformation';
 import VictimInformation from '@/Pages/Incident/Partials/ShowComponents/InformationComponents/VictimInformation';
 import WitnessInformation from '@/Pages/Incident/Partials/ShowComponents/InformationComponents/WitnessInformation';
@@ -18,7 +19,7 @@ export default function IncidentInformationPanel({ incident }: { incident: Incid
                 <Badge color={incidentBadgeColor(incident)} text={uppercaseWordFormat(incident.status)} />
             </div>
             <br />
-
+            <ReportingInformation incident={incident} />
             <AffectedPartyInformation incident={incident} />
             <GeneralDescription incident={incident} />
             <IncidentInformation incident={incident} />

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/AdditionalInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/AdditionalInformation.tsx
@@ -6,10 +6,10 @@ export default function AdditionalInformation({ incident }: { incident: Incident
     return (
         <>
             {incident.additional_information && incident.additional_information.length > 0 && (
-                <div className="mt-6 border-t border-gray-900/5 pt-6 sm:pr-4">
-                    <dt className="text-xl font-semibold text-gray-900">Additional Information</dt>
-                    <dd className="mt-2 ml-6 text-gray-500">
-                        <ul className="space-y-4 text-gray-900">
+                <div className="mt-6 border-t border-gray-900/5 pt-6 text-gray-900 sm:pr-4">
+                    <dt className="text-xl font-semibold">Additional Information</dt>
+                    <dd className="mt-2 ml-6">
+                        <ul className="space-y-4">
                             {incident.additional_information.map(({ information, created_at }, i) => (
                                 <li key={information + i}>
                                     <div className="font-medium text-gray-900">{uppercaseWordFormat(timeSince(created_at), ' ')}:</div>

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/AffectedPartyInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/AffectedPartyInformation.tsx
@@ -5,26 +5,24 @@ export default function AffectedPartyInformation({ incident }: { incident: Incid
     const [firstName, lastName] = nameFormat(incident);
 
     return (
-        <dl className="mt-6 border-t border-gray-900/5 pt-6 sm:pr-4">
-            <dt className="text-xl font-semibold text-gray-900">Affected Party Information</dt>
-            <dd className="mt-2 text-gray-500">
-                <div className="ml-6 text-gray-900">
-                    <div>
-                        <span className="font-semibold">Name: </span>
-                        {firstName} {lastName}
-                    </div>
-                    <div>
-                        <span className="font-semibold">UPEI ID: </span>
-                        {incident.upei_id ?? 'N/A'}
-                    </div>
-                    <div>
-                        <span className="font-semibold">Email: </span>
-                        {incident.email ?? 'Not Provided'}
-                    </div>
-                    <div>
-                        <span className="font-semibold">Phone: </span>
-                        {incident.phone ?? 'Not Provided'}
-                    </div>
+        <dl className="mt-6 border-t border-gray-900/5 pt-6 text-gray-900 sm:pr-4">
+            <dt className="text-xl font-semibold">Affected Party Information</dt>
+            <dd className="mt-2 ml-6">
+                <div>
+                    <span className="font-semibold">Name: </span>
+                    {firstName} {lastName}
+                </div>
+                <div>
+                    <span className="font-semibold">UPEI ID: </span>
+                    {incident.upei_id ?? 'N/A'}
+                </div>
+                <div>
+                    <span className="font-semibold">Email: </span>
+                    {incident.email ?? 'Not Provided'}
+                </div>
+                <div>
+                    <span className="font-semibold">Phone: </span>
+                    {incident.phone ?? 'Not Provided'}
                 </div>
             </dd>
         </dl>

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/GeneralDescription.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/GeneralDescription.tsx
@@ -4,37 +4,35 @@ import { Incident } from '@/types/incident/Incident';
 
 export default function GeneralDescription({ incident }: { incident: Incident }) {
     return (
-        <dl className="mt-6 border-t border-gray-900/5 pt-6 sm:pr-4">
-            <dt className="text-xl font-semibold text-gray-900">General Description</dt>
-            <dd className="mt-2 ml-6 text-gray-500">
-                <span className="text-gray-900">
-                    <div>
-                        <span className="font-semibold">Type: </span>
-                        {incident.incident_type === IncidentType.ENVIRONMENTAL
-                            ? 'Environmental'
-                            : incident.incident_type === IncidentType.SAFETY
-                              ? 'Safety'
-                              : incident.incident_type === IncidentType.SECURITY
-                                ? 'Security'
-                                : 'Unknown'}
-                    </div>
-                    <div>
-                        <span className="font-semibold">Descriptor: </span>
-                        {incident.descriptor}
-                    </div>
-                    <div>
-                        <span className="font-semibold">Description: </span>
-                        {incident.description ?? 'None Provided'}
-                    </div>
-                    <div>
-                        <span className="font-semibold">Created at: </span>
-                        {dateTimeFormat(incident.created_at)}
-                    </div>
-                    <div>
-                        <span className="font-semibold">Updated at: </span>
-                        {dateTimeFormat(incident.updated_at)}
-                    </div>
-                </span>
+        <dl className="mt-6 border-t border-gray-900/5 pt-6 text-gray-900 sm:pr-4">
+            <dt className="text-xl font-semibold">General Description</dt>
+            <dd className="mt-2 ml-6">
+                <div>
+                    <span className="font-semibold">Type: </span>
+                    {incident.incident_type === IncidentType.ENVIRONMENTAL
+                        ? 'Environmental'
+                        : incident.incident_type === IncidentType.SAFETY
+                          ? 'Safety'
+                          : incident.incident_type === IncidentType.SECURITY
+                            ? 'Security'
+                            : 'Unknown'}
+                </div>
+                <div>
+                    <span className="font-semibold">Descriptor: </span>
+                    {incident.descriptor}
+                </div>
+                <div>
+                    <span className="font-semibold">Description: </span>
+                    {incident.description ?? 'None Provided'}
+                </div>
+                <div>
+                    <span className="font-semibold">Created at: </span>
+                    {dateTimeFormat(incident.created_at)}
+                </div>
+                <div>
+                    <span className="font-semibold">Updated at: </span>
+                    {dateTimeFormat(incident.updated_at)}
+                </div>
             </dd>
         </dl>
     );

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/IncidentInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/IncidentInformation.tsx
@@ -3,27 +3,25 @@ import { Incident } from '@/types/incident/Incident';
 
 export default function IncidentInformation({ incident }: { incident: Incident }) {
     return (
-        <dl className="mt-6 border-t border-gray-900/5 pt-6 sm:pr-4">
-            <dt className="text-xl font-semibold text-gray-900">Incident Information</dt>
-            <dd className="mt-2 ml-6 text-gray-500">
-                <span className="text-gray-900">
-                    <div>
-                        <span className="font-semibold">Work Related: </span>
-                        {incident.work_related ? 'Yes' : 'No'}
-                    </div>
-                    <div>
-                        <span className="font-semibold">Happened At: </span>
-                        {dateTimeFormat(incident.happened_at)}
-                    </div>
-                    <div>
-                        <span className="font-semibold">Location: </span>
-                        {incident.location ?? 'Not Provided'}
-                    </div>
-                    <div>
-                        <span className="font-semibold">Room Number: </span>
-                        {incident.room_number || 'N/A'}
-                    </div>
-                </span>
+        <dl className="mt-6 border-t border-gray-900/5 pt-6 text-gray-900 sm:pr-4">
+            <dt className="text-xl font-semibold">Incident Information</dt>
+            <dd className="mt-2 ml-6">
+                <div>
+                    <span className="font-semibold">Work Related: </span>
+                    {incident.work_related ? 'Yes' : 'No'}
+                </div>
+                <div>
+                    <span className="font-semibold">Happened At: </span>
+                    {dateTimeFormat(incident.happened_at)}
+                </div>
+                <div>
+                    <span className="font-semibold">Location: </span>
+                    {incident.location ?? 'Not Provided'}
+                </div>
+                <div>
+                    <span className="font-semibold">Room Number: </span>
+                    {incident.room_number || 'N/A'}
+                </div>
             </dd>
         </dl>
     );

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/ReportingInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/ReportingInformation.tsx
@@ -1,0 +1,31 @@
+import { Incident } from '@/types/incident/Incident';
+
+export default function ReportingInformation({ incident }: { incident: Incident }) {
+    return (
+        <dl className="mt-6 border-t border-gray-900/5 pt-6 text-gray-900 sm:pr-4">
+            <dt className="text-xl font-semibold">Reporting Information</dt>
+            <dl className="mt-2 ml-6">
+                <div>
+                    <span className="font-semibold">Anonymous: </span>
+                    {incident.anonymous ? 'Yes' : 'No'}
+                </div>
+                {!incident.anonymous && incident.on_behalf && (
+                    <div>
+                        <span className="font-semibold">Reporters Email: </span>
+                        {incident.reporters_email}
+                    </div>
+                )}
+                <div>
+                    <span className="font-semibold">On Behalf: </span>
+                    {incident.on_behalf ? 'Yes' : 'No'}
+                </div>
+                {incident.on_behalf && (
+                    <div>
+                        <span className="font-semibold">On Behalf Anonymous: </span>
+                        {incident.on_behalf_anonymous ? 'Yes' : 'No'}
+                    </div>
+                )}
+            </dl>
+        </dl>
+    );
+}

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/SupervisorInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/SupervisorInformation.tsx
@@ -4,17 +4,17 @@ export default function SupervisorInformation({ incident }: { incident: Incident
     return (
         <>
             {(incident.supervisor_name || incident.supervisor) && (
-                <dl className="mt-6 border-t border-gray-900/5 pt-6 sm:pr-4">
-                    <dt className="text-xl font-semibold text-gray-900">Supervisor</dt>
+                <dl className="mt-6 border-t border-gray-900/5 pt-6 text-gray-900 sm:pr-4">
+                    <dt className="text-xl font-semibold">Supervisor</dt>
                     <dd className="mt-2 ml-6">
                         {incident.supervisor && (
                             <>
                                 <div>
-                                    <span className="font-semibold text-gray-900">Name: </span>
+                                    <span className="font-semibold">Name: </span>
                                     {incident.supervisor.name}
                                 </div>
                                 <div>
-                                    <span className="font-semibold text-gray-900">Email: </span>
+                                    <span className="font-semibold">Email: </span>
                                     {incident.supervisor.email}
                                 </div>
 
@@ -23,7 +23,7 @@ export default function SupervisorInformation({ incident }: { incident: Incident
                         )}
                         {incident.supervisor_name && (
                             <div>
-                                <span className="font-semibold text-gray-900">Reported Supervisor Name: </span>
+                                <span className="font-semibold">Reported Supervisor Name: </span>
                                 {incident.supervisor_name}
                             </div>
                         )}

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/VictimInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/VictimInformation.tsx
@@ -2,19 +2,17 @@ import { Incident } from '@/types/incident/Incident';
 
 export default function VictimInformation({ incident }: { incident: Incident }) {
     return (
-        <dl className="mt-6 border-t border-gray-900/5 pt-6 sm:pr-4">
-            <dt className="text-xl font-semibold text-gray-900">Incident Information</dt>
-            <dd className="mt-2 ml-6 text-gray-500">
-                <span className="text-gray-900">
-                    <div>
-                        <span className="font-semibold">Injury Description: </span>
-                        {incident.injury_description || 'No injuries were sustained'}
-                    </div>
-                    <div>
-                        <span className="font-semibold">First-Aid: </span>
-                        {incident.first_aid_description || 'No first-aid was administered'}
-                    </div>
-                </span>
+        <dl className="mt-6 border-t border-gray-900/5 pt-6 text-gray-900 sm:pr-4">
+            <dt className="text-xl font-semibold">Incident Information</dt>
+            <dd className="mt-2 ml-6">
+                <div>
+                    <span className="font-semibold">Injury Description: </span>
+                    {incident.injury_description || 'No injuries were sustained'}
+                </div>
+                <div>
+                    <span className="font-semibold">First-Aid: </span>
+                    {incident.first_aid_description || 'No first-aid was administered'}
+                </div>
             </dd>
         </dl>
     );

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/WitnessInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/WitnessInformation.tsx
@@ -2,11 +2,11 @@ import { Incident } from '@/types/incident/Incident';
 
 export default function WitnessInformation({ incident }: { incident: Incident }) {
     return (
-        <div className="mt-6 border-t border-gray-900/5 pt-6 sm:pr-4">
-            <dt className="text-xl font-semibold text-gray-900">Witnesses</dt>
-            <dd className="mt-2 ml-6 text-gray-500">
+        <div className="mt-6 border-t border-gray-900/5 pt-6 text-gray-900 sm:pr-4">
+            <dt className="text-xl font-semibold">Witnesses</dt>
+            <dd className="mt-2 ml-6">
                 {incident.witnesses && incident.witnesses.length > 0 ? (
-                    <ul className="list-none text-gray-900">
+                    <ul className="list-none">
                         {incident.witnesses.map((witness, index) => (
                             <li key={index} className="mb-4 flex flex-col gap-y-0">
                                 <div className="flex items-center gap-x-1">


### PR DESCRIPTION
# Feature Addition [CLOSES #293]

## Summary

Adds missing information to incident show page

## Rationale

Showing additional information that we are storing

## Design Documentation

NA

## Changes

- Created a ReportingInformation component containing is anonymous, is on behalf, is on behalf anonymous, and reporters email.
- on behalf anonymous only shows if on behalf is true
- Reporters email only shows if not anonymous and on behalf.
- Removes redundant class names from remaining incident show components
- Changes 'Reporter' to 'Name' on Incident index page as 'Reporter' is misleading.

## Impact

NA

## Testing

NA

## Screenshots/Video
![image](https://github.com/user-attachments/assets/4f941e87-6427-4fe6-9027-f42bbdac8414)

## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [x] The documentation has been updated to reflect the new feature

## Additional Notes
NA
