### PR TITLE
closed_at timestamp now set

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Lint Frontend
         run: npm run lint
 
-#      - name: Commit Changes
-#        uses: stefanzweifel/git-auto-commit-action@v5
-#        with:
-#          commit_message: fix code style
-#          commit_options: '--no-verify'
+      - name: Commit Changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: fix code style
+          commit_options: '--no-verify'

--- a/app/StorableEvents/Incident/IncidentClosed.php
+++ b/app/StorableEvents/Incident/IncidentClosed.php
@@ -17,6 +17,7 @@ class IncidentClosed extends StoredEvent
     {
         $incident = Incident::find($this->aggregateRootUuid());
         $incident->status->transitionTo(Closed::class);
+        $incident->closed_at = now();
         $incident->save();
 
         $comment = new Comment;

--- a/app/StorableEvents/Incident/IncidentCreated.php
+++ b/app/StorableEvents/Incident/IncidentCreated.php
@@ -60,7 +60,7 @@ class IncidentCreated extends StoredEvent
         $incident->phone = $this->phone;
         $incident->work_related = $this->work_related;
         $incident->workers_comp_submitted = $this->workers_comp_submitted;
-        $incident->happened_at = $this->happened_at;
+        $incident->happened_at = $this->happened_at->toDateString();
         $incident->location = $this->location;
         $incident->room_number = $this->room_number;
         $incident->witnesses = $this->witnesses;

--- a/app/StorableEvents/Incident/IncidentReopened.php
+++ b/app/StorableEvents/Incident/IncidentReopened.php
@@ -18,6 +18,7 @@ class IncidentReopened extends StoredEvent
         $incident = Incident::find($this->aggregateRootUuid());
         $incident->status->transitionTo(Reopened::class);
         $incident->supervisor_id = null;
+        $incident->closed_at = null;
         $incident->save();
 
         $comment = new Comment;

--- a/database/migrations/2025_01_10_151039_create_incidents_table.php
+++ b/database/migrations/2025_01_10_151039_create_incidents_table.php
@@ -34,7 +34,7 @@ return new class () extends Migration {
             $table->boolean('work_related');
             $table->boolean('workers_comp_submitted');
 
-            $table->datetime('happened_at')->nullable();
+            $table->date('happened_at')->nullable();
 
             $table->string('location')->nullable();
             $table->index('location');

--- a/resources/js/Pages/Incident/Partials/ShowComponents/ActivityLog.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/ActivityLog.tsx
@@ -3,16 +3,15 @@ import classNames from '@/Formatters/classNames';
 import AddCommentForm from '@/Pages/Incident/Partials/ShowComponents/ActivityLogComponents/AddCommentForm';
 import ActionComment from '@/Pages/Incident/Partials/ShowComponents/ActivityLogComponents/CommentComponents/ActionComment';
 import NoteComment from '@/Pages/Incident/Partials/ShowComponents/ActivityLogComponents/CommentComponents/NoteComment';
-import { Comment } from '@/types/Comment';
+import { Incident } from '@/types/incident/Incident';
+import { useForm } from '@inertiajs/react';
 import { FormEvent, useEffect, useRef } from 'react';
-import {useForm} from "@inertiajs/react";
-import {Incident} from "@/types/incident/Incident";
 
 interface ActivityLogProps {
-  incident: Incident
+    incident: Incident;
 }
 
-export default function ActivityLog({ incident}: ActivityLogProps) {
+export default function ActivityLog({ incident }: ActivityLogProps) {
     const { data, setData, post, processing, reset } = useForm({
         content: '',
     });

--- a/resources/js/Pages/Incident/Partials/ShowComponents/AdminActionsComponents/StatusUpdate.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/AdminActionsComponents/StatusUpdate.tsx
@@ -7,10 +7,10 @@ import { useState } from 'react';
 
 import { useConfirmationModal } from '@/Components/ConfirmationModal/ConfirmationModalProvider';
 import DangerButton from '@/Components/DangerButton';
+import FileIcon from '@/Components/FileIcon';
+import dateFormat from '@/Formatters/dateFormat';
 import dateTimeFormat from '@/Formatters/dateTimeFormat';
 import { closeIncident, reopenIncident, returnInvestigation, returnRCA } from '@/Helpers/Incident/statusUpdates';
-import FileIcon from "@/Components/FileIcon";
-import dateFormat from "@/Formatters/dateFormat";
 
 export default function StatusUpdate({ incident }: { incident: Incident }) {
     const [isLoading, setIsLoading] = useState(false);

--- a/resources/js/Pages/Incident/Partials/ShowComponents/IncidentSupervisorActions.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/IncidentSupervisorActions.tsx
@@ -6,7 +6,6 @@ import dateFormat from '@/Formatters/dateFormat';
 import dateTimeFormat from '@/Formatters/dateTimeFormat';
 import FileUploadModal from '@/Pages/Incident/Partials/ShowComponents/FileUploadModal';
 import { Link } from '@inertiajs/react';
-import dayjs from 'dayjs';
 import { useState } from 'react';
 
 interface SupervisorActionsProps {

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/GeneralDescription.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/GeneralDescription.tsx
@@ -26,12 +26,8 @@ export default function GeneralDescription({ incident }: { incident: Incident })
                     {incident.description ?? 'None Provided'}
                 </div>
                 <div>
-                    <span className="font-semibold">Created at: </span>
+                    <span className="font-semibold">Submitted at: </span>
                     {dateTimeFormat(incident.created_at)}
-                </div>
-                <div>
-                    <span className="font-semibold">Updated at: </span>
-                    {dateTimeFormat(incident.updated_at)}
                 </div>
             </dd>
         </dl>

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/IncidentInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/IncidentInformation.tsx
@@ -1,5 +1,5 @@
+import dateFormat from '@/Formatters/dateFormat';
 import { Incident } from '@/types/incident/Incident';
-import dateFormat from "@/Formatters/dateFormat";
 
 export default function IncidentInformation({ incident }: { incident: Incident }) {
     return (

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/IncidentInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/IncidentInformation.tsx
@@ -1,5 +1,5 @@
-import dateTimeFormat from '@/Formatters/dateTimeFormat';
 import { Incident } from '@/types/incident/Incident';
+import dateFormat from "@/Formatters/dateFormat";
 
 export default function IncidentInformation({ incident }: { incident: Incident }) {
     return (
@@ -12,7 +12,7 @@ export default function IncidentInformation({ incident }: { incident: Incident }
                 </div>
                 <div>
                     <span className="font-semibold">Happened At: </span>
-                    {dateTimeFormat(incident.happened_at)}
+                    {dateFormat(incident.happened_at)}
                 </div>
                 <div>
                     <span className="font-semibold">Location: </span>

--- a/resources/js/Pages/Incident/Stages/IncidentInformationStage.tsx
+++ b/resources/js/Pages/Incident/Stages/IncidentInformationStage.tsx
@@ -17,7 +17,7 @@ export default function IncidentInformationStage({ formData, setFormData }: Stag
                     <DateInput
                         value={formData.happened_at ?? dateFormat(new Date())}
                         onChange={(e) => {
-                            setFormData('happened_at', e.target.value);
+                            setFormData('happened_at', dateFormat(e.target.value));
                         }}
                     />
                 </div>

--- a/resources/js/ssr.tsx
+++ b/resources/js/ssr.tsx
@@ -1,10 +1,10 @@
+import ConfirmationModalProvider from '@/Components/ConfirmationModal/ConfirmationModalProvider';
 import { createInertiaApp } from '@inertiajs/react';
 import createServer from '@inertiajs/react/server';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import ReactDOMServer from 'react-dom/server';
 import { RouteName } from 'ziggy-js';
 import { route } from '../../vendor/tightenco/ziggy';
-import ConfirmationModalProvider from "@/Components/ConfirmationModal/ConfirmationModalProvider";
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -13,8 +13,7 @@ createServer((page) =>
         page,
         render: ReactDOMServer.renderToString,
         title: (title) => `${title} - ${appName}`,
-        resolve: (name) =>
-            resolvePageComponent(`./Pages/${name}.tsx`, import.meta.glob('./Pages/**/*.tsx')),
+        resolve: (name) => resolvePageComponent(`./Pages/${name}.tsx`, import.meta.glob('./Pages/**/*.tsx')),
         setup: ({ App, props }) => {
             /* eslint-disable */
             // @ts-expect-error
@@ -25,9 +24,11 @@ createServer((page) =>
                 });
             /* eslint-enable */
 
-            return <ConfirmationModalProvider>
-                <App {...props} />
-            </ConfirmationModalProvider>
+            return (
+                <ConfirmationModalProvider>
+                    <App {...props} />
+                </ConfirmationModalProvider>
+            );
         },
     }),
 );

--- a/tests/Feature/Incident/StoreTest.php
+++ b/tests/Feature/Incident/StoreTest.php
@@ -257,7 +257,7 @@ class StoreTest extends TestCase
         $this->assertNull($incident->email);
         $this->assertNull($incident->phone);
         $this->assertEquals($incidentData->work_related, $incident->work_related);
-        $this->assertEquals($incidentData->happened_at, $incident->happened_at);
+        $this->assertEquals($incidentData->happened_at->toDateString(), $incident->happened_at);
         $this->assertEquals($incidentData->location, $incident->location);
         $this->assertNull($incident->room_number);
         $this->assertNull($incident->witnesses);
@@ -358,7 +358,7 @@ class StoreTest extends TestCase
         $this->assertEquals($incidentData->phone, $incident->phone);
         $this->assertEquals($incidentData->work_related, $incident->work_related);
         $this->assertEquals($incidentData->workers_comp_submitted, $incident->workers_comp_submitted);
-        $this->assertEquals($incidentData->happened_at, $incident->happened_at);
+        $this->assertEquals($incidentData->happened_at->toDateString(), $incident->happened_at);
         $this->assertEquals($incidentData->location, $incident->location);
         $this->assertEquals($incidentData->room_number, $incident->room_number);
         $this->assertEquals($incidentData->witnesses, $incident->witnesses);

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -991,7 +991,7 @@ class IncidentAggregateRootTest extends TestCase
         $this->assertEquals($incidentData->phone, $incident->phone);
         $this->assertEquals($incidentData->work_related, $incident->work_related);
         $this->assertEquals($incidentData->workers_comp_submitted, $incident->workers_comp_submitted);
-        $this->assertEquals($incidentData->happened_at, $incident->happened_at);
+        $this->assertEquals($incidentData->happened_at->toDateString(), $incident->happened_at);
         $this->assertEquals($incidentData->location, $incident->location);
         $this->assertEquals($incidentData->room_number, $incident->room_number);
         $this->assertEquals($incidentData->witnesses, $incident->witnesses);

--- a/tests/Unit/StoreableEvents/Incident/IncidentClosedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentClosedTest.php
@@ -14,6 +14,31 @@ use Tests\TestCase;
 
 class IncidentClosedTest extends TestCase
 {
+    public function test_sets_closed_at_timestamp()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => InReview::class,
+        ]);
+
+
+        $event = new IncidentClosed;
+        $event->setMetaData(['user_id' => $supervisor->id]);
+        $event->setAggregateRootUuid($incident->id);
+
+
+        $this->assertNull($incident->closed_at);
+
+        $event->handle();
+
+        $incident->refresh();
+
+        $this->assertNotNull($incident->closed_at);
+        $this->assertEquals(now(), $incident->closed_at);
+    }
+
     public function test_adds_closed_comment()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');

--- a/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentCreatedTest.php
@@ -17,6 +17,40 @@ use Tests\TestCase;
 
 class IncidentCreatedTest extends TestCase
 {
+    public function test_happened_at_date_only()
+    {
+        $event = new IncidentCreated(
+            anonymous: false,
+            on_behalf: false,
+            on_behalf_anonymous: false,
+            role: '0',
+            last_name: 'last',
+            first_name: 'first',
+            upei_id: '322',
+            email: 'john@doe.com',
+            phone: '(902) 333-4444',
+            work_related: true,
+            workers_comp_submitted: true,
+            happened_at: now(),
+            location: 'Building A',
+            room_number: '123A',
+            witnesses: [],
+            incident_type: IncidentType::SAFETY,
+            descriptor: 'Burn',
+            description: 'A fire broke out in the room.',
+            injury_description: 'Minor burn',
+            first_aid_description: 'Minor burn treated',
+            reporters_email: 'jane@doe.com',
+            supervisor_name: 'John Doe',
+        );
+
+        $event->handle();
+
+        $incident = Incident::first();
+
+        $this->assertEquals(now()->toDateString(), $incident->happened_at);
+    }
+
     public function test_adds_created_comment()
     {
         $event = new IncidentCreated(
@@ -107,7 +141,7 @@ class IncidentCreatedTest extends TestCase
         $this->assertEquals($event->phone, $incident->phone);
         $this->assertTrue($event->work_related, $incident->work_related);
         $this->assertTrue($event->workers_comp_submitted, $incident->workers_comp_submitted);
-        $this->assertEquals($event->happened_at, $incident->happened_at);
+        $this->assertEquals($event->happened_at->toDateString(), $incident->happened_at);
         $this->assertEquals($event->location, $incident->location);
         $this->assertEquals($event->room_number, $incident->room_number);
         $this->assertEquals($event->witnesses, $incident->witnesses);
@@ -168,7 +202,7 @@ class IncidentCreatedTest extends TestCase
         $this->assertNull($incident->phone);
         $this->assertEquals($event->work_related, $incident->work_related);
         $this->assertTrue($event->workers_comp_submitted, $incident->workers_comp_submitted);
-        $this->assertEquals($event->happened_at, $incident->happened_at);
+        $this->assertEquals($event->happened_at->toDateString(), $incident->happened_at);
         $this->assertEquals($event->location, $incident->location);
         $this->assertNull($incident->room_number);
         $this->assertNull($incident->witnesses);

--- a/tests/Unit/StoreableEvents/Incident/IncidentReopenedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReopenedTest.php
@@ -16,6 +16,24 @@ use Tests\TestCase;
 
 class IncidentReopenedTest extends TestCase
 {
+    public function test_reopen_incident_resets_closed_at()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $incident = Incident::factory()->create([
+            'supervisor_id' => $supervisor->id,
+            'status' => Closed::class,
+        ]);
+
+        $event = new IncidentReopened;
+        $event->setMetaData(['user_id' => $supervisor->id]);
+        $event->setAggregateRootUuid($incident->id);
+        $event->handle();
+
+        $incident->refresh();
+        $this->assertNull($incident->closed_at);
+    }
+
     public function test_throws_if_not_closed()
     {
         $this->expectException(TransitionNotFound::class);


### PR DESCRIPTION
# Bug Fix

## Summary

Closed at timestamp is now set when an incident is closed. Will be reset if reopened.

## Issue Link

FIXES #292
FIXES #294

## Root Cause Analysis

Closed at was never being set in event.

## Changes

closed_at is now set when closed event is fired.

Also corrects happened_at having a time attached to it.

## Impact

N/A

## Testing Strategy

Unit test has been added to verify this implementation.

## Regression Risk

N/A

## Checklist

- [ ] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes

N/A
