### PR TITLE
Adds concurrency group to deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - staging
 
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+  
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Feature Addition

## Summary

Adds concurrency group to deploy action

## Rationale

Multiple deploy actions running at once will cause issues. This will cancel any running deploy jobs when a new one starts.

## Design Documentation
NA

## Changes

Adds concurrency group with cancel-in-progress: true

## Impact

NA

## Testing

NA

## Screenshots/Video
NA

## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

NA
