### PR TITLE
Fixes comments not wrapping

### DIFF
--- a/resources/js/Pages/Incident/Partials/ShowComponents/ActivityLogComponents/CommentComponents/ActionComment.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/ActivityLogComponents/CommentComponents/ActionComment.tsx
@@ -8,8 +8,8 @@ export default function ActionComment({ comment }: { comment: Comment }) {
             <div className="relative flex size-6 flex-none items-center justify-center bg-white">
                 <InformationCircleIcon aria-hidden="true" className="text-upei-red-500 size-6" />
             </div>
-            <div className="flex-auto py-0.5 text-xs/5 text-gray-500">
-                <div>
+            <div className="w-[33%] flex-auto py-0.5 text-xs/5 text-gray-500">
+                <div className="break-words whitespace-normal">
                     <span className="font-medium text-gray-900">{comment.user?.name ?? 'Anonymous User'}</span> {comment.content}
                 </div>
 

--- a/resources/js/Pages/Incident/Partials/ShowComponents/ActivityLogComponents/CommentComponents/NoteComment.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/ActivityLogComponents/CommentComponents/NoteComment.tsx
@@ -7,7 +7,7 @@ export default function NoteComment({ comment }: { comment: Comment }) {
         <>
             <ChatBubbleBottomCenterTextIcon className="text-upei-green-600 relative flex size-6 flex-none items-center justify-center bg-white" />
 
-            <div className="flex-auto rounded-md p-3 ring-1 ring-gray-200 ring-inset">
+            <div className="w-[33%] flex-auto rounded-md p-3 ring-1 ring-gray-200 ring-inset">
                 <div className="flex justify-between gap-x-4">
                     <div className="py-0.5 text-xs/5 text-gray-500">
                         <div>
@@ -20,7 +20,7 @@ export default function NoteComment({ comment }: { comment: Comment }) {
                         </div>
                     </div>
                 </div>
-                <div className="text-sm/6 text-gray-500">{comment.content}</div>
+                <div className="text-sm/6 break-words whitespace-normal text-gray-500">{comment.content}</div>
             </div>
         </>
     );


### PR DESCRIPTION
# Bug Fix

## Summary

Fixes comments not wrapping

## Issue Link

Fixes #311 

## Root Cause Analysis

No max width on comment container

## Changes

- Adds max width to ActionComment and NoteComment containers
- Adds line wrapping behavior to comment content container

![image](https://github.com/user-attachments/assets/dd9a4017-26d4-4ff5-bfd9-719c6e7867f3)

![image](https://github.com/user-attachments/assets/fe6437f1-eecf-42a6-90ab-355c3c1fa2b3)


## Impact

NA

## Testing Strategy
1. Make long comment
2. See that it wraps

## Regression Risk
NA

## Checklist

- [x] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [x] The documentation has been updated if necessary

## Additional Notes
NA