### PR TITLE
Fixes supervisor id null error when creating/assigning

### DIFF
--- a/resources/js/Pages/Dashboard/Partials/AddUserModal.tsx
+++ b/resources/js/Pages/Dashboard/Partials/AddUserModal.tsx
@@ -17,9 +17,10 @@ interface AddUserFormProps {
     isOpen: boolean;
     onClose: (userCreated: boolean) => void;
     assignToIncidentId?: string;
+    withRole?: boolean;
 }
 
-export default function AddUserModal({ roles, isOpen, onClose, assignToIncidentId }: AddUserFormProps) {
+export default function AddUserModal({ roles, isOpen, onClose, assignToIncidentId, withRole = true }: AddUserFormProps) {
     const { data, setData, post, processing, errors, clearErrors, reset, cancel } = useForm({
         name: '',
         email: '',
@@ -159,7 +160,12 @@ export default function AddUserModal({ roles, isOpen, onClose, assignToIncidentI
                 <div className="mt-4">
                     <InputLabel htmlFor="role" value="Role" />
 
-                    <SelectInput value={data.role} onChange={(e) => setData('role', e.target.value)} className="w-full">
+                    <SelectInput
+                        disabled={!withRole}
+                        value={data.role}
+                        onChange={(e) => setData('role', e.target.value)}
+                        className="w-full disabled:text-gray-600"
+                    >
                         {roles.map(({ name }, index) => (
                             <option className="hover:bg-upei-green-500" key={index} value={name}>
                                 {uppercaseWordFormat(name, '-')}

--- a/resources/js/Pages/Incident/Partials/ShowComponents/AdminActionsComponents/SupervisorUpdate.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/AdminActionsComponents/SupervisorUpdate.tsx
@@ -43,6 +43,7 @@ export default function SupervisorUpdate({ incident, supervisors, roles }: Super
                     setIsUserFormOpen(false);
                 }}
                 assignToIncidentId={incident.id}
+                withRole={false}
             />
             <label className="mt-6 block text-sm/6 font-medium text-gray-900">Supervisor Management</label>
 

--- a/resources/js/Pages/Incident/Partials/ShowComponents/AdminActionsComponents/SupervisorUpdate.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/AdminActionsComponents/SupervisorUpdate.tsx
@@ -42,7 +42,7 @@ export default function SupervisorUpdate({ incident, supervisors, roles }: Super
                     }
                     setIsUserFormOpen(false);
                 }}
-                assignToIncidentId={incident.slug}
+                assignToIncidentId={incident.id}
             />
             <label className="mt-6 block text-sm/6 font-medium text-gray-900">Supervisor Management</label>
 


### PR DESCRIPTION
# Bug Fix

## Summary

Fixes null error when creating supervisor from assignment dropdown

## Issue Link
Fixes #323 

## Root Cause Analysis

Incident slug was being passed instead of incident id

## Changes

Changed $incident->slug to $incident->id on SupervisorAssigned.tsx

## Impact

NA

## Testing Strategy

Create supervisor from assigned dropdown

## Regression Risk
NA

## Checklist

- [x] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes

NA