### PR TITLE
Adds average days open to admin dashboard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
       mysql:
         image: mysql:8
         env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: testing
-          MYSQL_USER: user
-          MYSQL_PASSWORD: password
+          MYSQL_ROOT_PASSWORD: ${{secrets.TEST_DB_ROOT_PASSWORD}}
+          MYSQL_DATABASE: ${{secrets.TEST_DB_DATABASE}}
+          MYSQL_USER: ${{secrets.TEST_DB_USER}}
+          MYSQL_PASSWORD: ${{secrets.TEST_DB_PASSWORD}}
         ports:
           - 3306:3306
         options: >-
@@ -62,8 +62,8 @@ jobs:
       - name: Tests
         env:
           DB_HOST: 127.0.0.1
-          DB_DATABASE: testing
-          DB_USERNAME: user
-          DB_PASSWORD: password
+          DB_DATABASE: ${{secrets.TEST_DB_DATABASE}}
+          DB_USERNAME: ${{secrets.TEST_DB_USER}}
+          DB_PASSWORD: ${{secrets.TEST_DB_PASSWORD}}
 
         run: ./vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,9 +50,6 @@ jobs:
       - name: Build Assets
         run: npm run build
 
-      - name: Create SQLite Database
-        run: touch database/database.sqlite
-
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
@@ -64,6 +61,7 @@ jobs:
 
       - name: Tests
         env:
+          DB_CONNECTION: 127.0.0.1
           DB_DATABASE: testing
           DB_USERNAME: user
           DB_PASSWORD: password

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Tests
         env:
-          DB_CONNECTION: 127.0.0.1
+          DB_HOST: 127.0.0.1
           DB_DATABASE: testing
           DB_USERNAME: user
           DB_PASSWORD: password

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,10 @@ jobs:
 
       - name: Tests
         env:
-          DB_DATABASE: ${{secrets.TEST_DB_DATABASE}}
-          DB_USERNAME: ${{secrets.TEST_DB_USER}}
-          DB_PASSWORD: ${{secrets.TEST_DB_PASSWORD}}
+          DB_HOST: 127.0.0.1
+          DB_DATABASE: "${{ secrets.TEST_DB_DATABASE }}"
+          DB_USERNAME: "${{ secrets.TEST_DB_USER }}"
+          DB_PASSWORD: "${{ secrets.TEST_DB_PASSWORD }}"
+
 
         run: ./vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,21 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: testing
+          MYSQL_USER: user
+          MYSQL_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --host=127.0.0.1 --user=root --password=root"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,7 +63,4 @@ jobs:
         run: php artisan key:generate
 
       - name: Tests
-        env:
-          DB_CONNECTION: sqlite
-          DB_DATABASE: database/database.sqlite
         run: ./vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping --host=127.0.0.1 --user=root --password=${{secrets.TEST_DB_ROOT_PASSWORD}}"
+          --health-cmd="mysqladmin ping --host=127.0.0.1 --user=root --password=$TEST_DB_ROOT_PASSWORD"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,6 @@ jobs:
 
       - name: Tests
         env:
-          DB_HOST: 127.0.0.1
           DB_DATABASE: ${{secrets.TEST_DB_DATABASE}}
           DB_USERNAME: ${{secrets.TEST_DB_USER}}
           DB_PASSWORD: ${{secrets.TEST_DB_PASSWORD}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
         ports:
           - 3306:3306
         options: >-
+          --default-authentication-plugin=mysql_native_password
           --health-cmd="mysqladmin ping --host=127.0.0.1 --user=root --password=$TEST_DB_ROOT_PASSWORD"
           --health-interval=10s
           --health-timeout=5s

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping --host=127.0.0.1 --user=root --password=root"
+          --health-cmd="mysqladmin ping --host=127.0.0.1 --user=root --password=${{secrets.TEST_DB_ROOT_PASSWORD}}"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,6 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --default-authentication-plugin=mysql_native_password
           --health-cmd="mysqladmin ping --host=127.0.0.1 --user=root --password=$TEST_DB_ROOT_PASSWORD"
           --health-interval=10s
           --health-timeout=5s
@@ -66,6 +65,4 @@ jobs:
           DB_DATABASE: "${{ secrets.TEST_DB_DATABASE }}"
           DB_USERNAME: "${{ secrets.TEST_DB_USER }}"
           DB_PASSWORD: "${{ secrets.TEST_DB_PASSWORD }}"
-
-
         run: ./vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,4 +63,9 @@ jobs:
         run: php artisan key:generate
 
       - name: Tests
+        env:
+          DB_DATABASE: testing
+          DB_USERNAME: user
+          DB_PASSWORD: password
+
         run: ./vendor/bin/phpunit

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -43,12 +43,16 @@ class DashboardController extends Controller
         $incidentCount = Incident::count();
         $closedCount = Incident::whereState('status', Closed::class)->count();
         $unresolvedCount = $incidentCount - $closedCount;
+        $averageDaysOpen = Incident::whereNotNull('closed_at')
+            ->selectRaw('ROUND(AVG(DATEDIFF(closed_at, created_at)), 2) as average')
+            ->value('average');
 
         return Inertia::render('Dashboard/AdminOverview', [
             'incidents' => $incidents,
             'incidentCount' => $incidentCount,
             'closedCount' => $closedCount,
             'unresolvedCount' => $unresolvedCount,
+            'averageDaysOpen' => $averageDaysOpen,
         ]);
     }
 

--- a/composer.lock
+++ b/composer.lock
@@ -870,16 +870,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.342.0",
+            "version": "3.342.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "5b8c837ab0c9754ab3408bd9afe6f0c67516b1fd"
+                "reference": "8a4ba50aa12ce509d0e598a7fd65d6b9309c39dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/5b8c837ab0c9754ab3408bd9afe6f0c67516b1fd",
-                "reference": "5b8c837ab0c9754ab3408bd9afe6f0c67516b1fd",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/8a4ba50aa12ce509d0e598a7fd65d6b9309c39dd",
+                "reference": "8a4ba50aa12ce509d0e598a7fd65d6b9309c39dd",
                 "shasum": ""
             },
             "require": {
@@ -961,9 +961,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.342.0"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.342.1"
             },
-            "time": "2025-03-05T19:20:14+00:00"
+            "time": "2025-03-06T19:17:36+00:00"
         },
         {
             "name": "brick/math",
@@ -12114,16 +12114,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.11",
+            "version": "11.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3946ac38410be7440186c6e74584f31b15107fc7"
+                "reference": "d42785840519401ed2113292263795eb4c0f95da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3946ac38410be7440186c6e74584f31b15107fc7",
-                "reference": "3946ac38410be7440186c6e74584f31b15107fc7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d42785840519401ed2113292263795eb4c0f95da",
+                "reference": "d42785840519401ed2113292263795eb4c0f95da",
                 "shasum": ""
             },
             "require": {
@@ -12144,7 +12144,7 @@
                 "phpunit/php-timer": "^7.0.1",
                 "sebastian/cli-parser": "^3.0.2",
                 "sebastian/code-unit": "^3.0.2",
-                "sebastian/comparator": "^6.3.0",
+                "sebastian/comparator": "^6.3.1",
                 "sebastian/diff": "^6.0.2",
                 "sebastian/environment": "^7.2.0",
                 "sebastian/exporter": "^6.3.0",
@@ -12195,7 +12195,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.11"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.12"
             },
             "funding": [
                 {
@@ -12211,7 +12211,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-05T07:36:02+00:00"
+            "time": "2025-03-07T07:31:03+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -12385,16 +12385,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.3.0",
+            "version": "6.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "d4e47a769525c4dd38cea90e5dcd435ddbbc7115"
+                "reference": "24b8fbc2c8e201bb1308e7b05148d6ab393b6959"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/d4e47a769525c4dd38cea90e5dcd435ddbbc7115",
-                "reference": "d4e47a769525c4dd38cea90e5dcd435ddbbc7115",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/24b8fbc2c8e201bb1308e7b05148d6ab393b6959",
+                "reference": "24b8fbc2c8e201bb1308e7b05148d6ab393b6959",
                 "shasum": ""
             },
             "require": {
@@ -12413,7 +12413,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.2-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -12453,7 +12453,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.0"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.1"
             },
             "funding": [
                 {
@@ -12461,7 +12461,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-06T10:28:19+00:00"
+            "time": "2025-03-07T06:57:01+00:00"
         },
         {
             "name": "sebastian/complexity",

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -67,6 +67,7 @@ class DatabaseSeeder extends Seeder
         Incident::factory(5)->hasComments(5)->create([
             'supervisor_id' => $supervisor->id,
             'status' => InReview::class,
+            'created_at' => now()->subDays(rand(0, 60)),
         ])->each(function (Incident $incident) use ($supervisor) {
             Investigation::factory()->create(['supervisor_id' => $supervisor->id, 'incident_id' => $incident->id]);
             RootCauseAnalysis::factory()->create(['supervisor_id' => $supervisor->id, 'incident_id' => $incident->id]);
@@ -75,19 +76,23 @@ class DatabaseSeeder extends Seeder
         Incident::factory(5)->hasComments(5)->create([
             'supervisor_id' => $supervisor->id,
             'status' => Closed::class,
+            'created_at' => now()->subDays(rand(7, 60)),
             'closed_at' => now(),
         ]);
 
         Incident::factory(5)->create([
             'reporters_email' => $admin->email,
+            'created_at' => now()->subDays(rand(0, 60)),
         ]);
 
         Incident::factory(5)->create([
             'reporters_email' => $supervisor->email,
+            'created_at' => now()->subDays(rand(0, 60)),
         ]);
 
         Incident::factory(5)->create([
             'reporters_email' => $user->email,
+            'created_at' => now()->subDays(rand(0, 60)),
         ]);
     }
 }

--- a/resources/js/Pages/Dashboard/AdminOverview.tsx
+++ b/resources/js/Pages/Dashboard/AdminOverview.tsx
@@ -9,15 +9,16 @@ interface AdminDashboardProps {
     incidentCount: number;
     closedCount: number;
     unresolvedCount: number;
+    averageDaysOpen: number;
 }
 
-export default function AdminOverview({ incidents, incidentCount, closedCount, unresolvedCount }: AdminDashboardProps) {
+export default function AdminOverview({ incidents, incidentCount, closedCount, unresolvedCount, averageDaysOpen }: AdminDashboardProps) {
     return (
         <Authenticated>
             <Head title="Admin Overview" />
             <div className="px-4 sm:px-6 lg:px-8">
                 {/* Index Summary */}
-                <div className="grid grid-cols-1 gap-6 text-center md:grid-cols-2 lg:grid-cols-3">
+                <div className="grid grid-cols-1 gap-6 text-center md:grid-cols-2 lg:grid-cols-4">
                     {/* Incident Count Card */}
                     <div className="rounded-lg bg-white p-6 shadow-lg">
                         <h3 className="text-lg font-semibold text-gray-700">Total Incidents</h3>
@@ -90,6 +91,12 @@ export default function AdminOverview({ incidents, incidentCount, closedCount, u
                         >
                             {closedCount}
                         </Link>
+                    </div>
+
+                    {/* Average Days Open */}
+                    <div className="rounded-lg bg-white p-6 shadow-lg">
+                        <h3 className="text-lg font-semibold text-gray-700">Average Days Open</h3>
+                        <div className="text-upei-green-500 text-3xl font-bold">{averageDaysOpen}</div>
                     </div>
                 </div>
 

--- a/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/ReportingInformation.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/InformationComponents/ReportingInformation.tsx
@@ -1,5 +1,6 @@
 import dateTimeFormat from '@/Formatters/dateTimeFormat';
 import { Incident } from '@/types/incident/Incident';
+import dayjs from 'dayjs';
 
 export default function ReportingInformation({ incident }: { incident: Incident }) {
     return (
@@ -10,6 +11,18 @@ export default function ReportingInformation({ incident }: { incident: Incident 
                     <span className="font-semibold">Submitted at: </span>
                     {dateTimeFormat(incident.created_at)}
                 </div>
+                {incident.closed_at && (
+                    <>
+                        <div>
+                            <span className="font-semibold">Closed at: </span>
+                            {dateTimeFormat(incident.closed_at)}
+                        </div>
+                        <div>
+                            <span className="font-semibold">Opened for: </span>
+                            {dayjs(incident.closed_at).diff(dayjs(incident.created_at), 'day')} Days
+                        </div>
+                    </>
+                )}
                 <div>
                     <span className="font-semibold">Anonymous: </span>
                     {incident.anonymous ? 'Yes' : 'No'}

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -12,6 +12,31 @@ use Tests\TestCase;
 
 class DashboardTest extends TestCase
 {
+    public function test_admin_overview_returns_correct_days_open_average()
+    {
+        $admin = User::factory()->create()->syncRoles('admin');
+        $this->actingAs($admin);
+
+        Incident::factory(2)->create([
+            'created_at' => now()->subDays(7),
+            'closed_at' => now()
+        ]);
+
+        $this->assertDatabaseCount('incidents', 2);
+
+        $response = $this->get(route('dashboard.admin'));
+
+        $response->assertStatus(200);
+
+        $response->assertInertia(function (AssertableInertia $page) {
+            $page->component('Dashboard/AdminOverview')
+                ->has('averageDaysOpen')
+                ->where('averageDaysOpen', function ($daysOpen) {
+                    return round($daysOpen, 2) == 7.00;
+                });
+        });
+    }
+
     public function test_user_management_does_not_return_self()
     {
         $admin = User::factory()->create()->syncRoles('admin');


### PR DESCRIPTION
# Feature Addition [CLOSES #321]

## Summary

Adds average days open to admin dashboard

## Rationale

HSE wants this stat on admin dashbaord

## Design Documentation

NA

## Changes

- Updated dashboard controller to pass average days open to AdminDashboard
- Updated incident created_at in seeder to be a random date 60 days in the past.
- Updated Incident Show page to show incident closed date and days open when the incident is closed 
- Updates test action to use MySQL due to DATEDIFF not being a valid function in SQLite

## Impact

NA

## Testing

Added to test to check for correct average days open.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/636e718b-06af-40c0-b847-54ba2219c5a4)

![image](https://github.com/user-attachments/assets/79c6c631-e759-4657-b43c-87590ee08fff)

![image](https://github.com/user-attachments/assets/0f318d25-6370-4f2a-bdd7-11cc0dc7b3f8)


## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

NA
