### PR TITLE
Adds timeframe to stats

### DIFF
--- a/app/Http/Controllers/Report/ReportController.php
+++ b/app/Http/Controllers/Report/ReportController.php
@@ -6,6 +6,8 @@ use App\Enum\IncidentType;
 use App\Http\Controllers\Controller;
 use App\Models\Incident;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -25,12 +27,27 @@ class ReportController extends Controller
     /**
      * @throws AuthorizationException
      */
-    public function stats(): Response
+    public function stats(Request $request): Response
     {
         Gate::authorize('view-report-page');
 
+        $start = $request->date('start', 'Y-m-d');
+        $end = $request->date('end', 'Y-m-d');
+
+        if (! $start) {
+            $start = Carbon::now()->subYear()->startOfDay();
+        }
+
+        if (! $end) {
+            $end = Carbon::now()->endOfDay();
+        }
+
+        $incidents = Incident::query()->whereBetween('created_at', [$start, $end]);
+
         $closeTimes = Incident::selectRaw("DATEDIFF(closed_at, created_at) as diff")
-            ->whereNotNull('closed_at')->pluck('diff')->toArray();
+            ->whereNotNull('closed_at')
+            ->pluck('diff')
+            ->toArray();
 
         $closedCounts = array_count_values(array_map(function ($value) {
             if ($value < 1) {
@@ -46,41 +63,41 @@ class ReportController extends Controller
         }, $closeTimes));
 
         return Inertia::render('Report/Stats', [
-            'locationCount' => Incident::selectRaw('location, count(location) as total')
+            'locationCount' => $incidents->selectRaw('location, count(location) as total')
                 ->groupBy('location')
                 ->pluck('total', 'location'),
             'closedTimeCount' => $closedCounts,
-            'typeCount' => Incident::selectRaw('incident_type, count(incident_type) as total')
+            'typeCount' => $incidents->selectRaw('incident_type, count(incident_type) as total')
                 ->groupBy('incident_type')
                 ->pluck('total', 'incident_type'),
-            'roleCount' => Incident::selectRaw('role, count(role) as total')
+            'roleCount' => $incidents->selectRaw('role, count(role) as total')
                 ->groupBy('role')
                 ->pluck('total', 'role'),
-            'statusCount' => Incident::selectRaw('status, count(status) as total')
+            'statusCount' => $incidents->selectRaw('status, count(status) as total')
                 ->groupBy('status')
                 ->pluck('total', 'status'),
-            'anonymousCount' => Incident::selectRaw('anonymous, count(anonymous) as total')
+            'anonymousCount' => $incidents->selectRaw('anonymous, count(anonymous) as total')
                 ->groupBy('anonymous')
                 ->pluck('total', 'anonymous'),
-            'descriptorCount' => Incident::selectRaw('descriptor, count(descriptor) as total')
+            'descriptorCount' => $incidents->selectRaw('descriptor, count(descriptor) as total')
                 ->groupBy('descriptor')
                 ->pluck('total', 'descriptor'),
-            'safetyCount' => Incident::selectRaw('descriptor, count(descriptor) as total')
+            'safetyCount' => $incidents->selectRaw('descriptor, count(descriptor) as total')
                 ->where('incident_type', IncidentType::SAFETY)
                 ->groupBy('descriptor')
                 ->pluck('total', 'descriptor'),
-            'environmentalCount' => Incident::selectRaw('descriptor, count(descriptor) as total')
+            'environmentalCount' => $incidents->selectRaw('descriptor, count(descriptor) as total')
                 ->where('incident_type', IncidentType::ENVIRONMENTAL)
                 ->groupBy('descriptor')
                 ->pluck('total', 'descriptor'),
-            'securityCount' => Incident::selectRaw('descriptor, count(descriptor) as total')
+            'securityCount' => $incidents->selectRaw('descriptor, count(descriptor) as total')
                 ->where('incident_type', IncidentType::SECURITY)
                 ->groupBy('descriptor')
                 ->pluck('total', 'descriptor'),
-            'onBehalfCount' => Incident::selectRaw('on_behalf, count(on_behalf) as total')
+            'onBehalfCount' => $incidents->selectRaw('on_behalf, count(on_behalf) as total')
                 ->groupBy('on_behalf')
                 ->pluck('total', 'on_behalf'),
-            'onBehalfAnonymousCount' => Incident::selectRaw('on_behalf_anonymous, count(on_behalf_anonymous) as total')
+            'onBehalfAnonymousCount' => $incidents->selectRaw('on_behalf_anonymous, count(on_behalf_anonymous) as total')
                 ->groupBy('on_behalf_anonymous')
                 ->pluck('total', 'on_behalf_anonymous'),
 

--- a/app/Http/Controllers/Report/ReportController.php
+++ b/app/Http/Controllers/Report/ReportController.php
@@ -42,7 +42,7 @@ class ReportController extends Controller
             $end = Carbon::now()->endOfDay();
         }
 
-        $incidents = Incident::query()->whereBetween('created_at', [$start, $end]);
+        $incidentsQuery = Incident::query()->whereBetween('created_at', [$start, $end]);
 
         $closeTimes = Incident::selectRaw("DATEDIFF(closed_at, created_at) as diff")
             ->whereNotNull('closed_at')
@@ -63,41 +63,41 @@ class ReportController extends Controller
         }, $closeTimes));
 
         return Inertia::render('Report/Stats', [
-            'locationCount' => $incidents->selectRaw('location, count(location) as total')
+            'locationCount' => $incidentsQuery->selectRaw('location, count(location) as total')
                 ->groupBy('location')
                 ->pluck('total', 'location'),
             'closedTimeCount' => $closedCounts,
-            'typeCount' => $incidents->selectRaw('incident_type, count(incident_type) as total')
+            'typeCount' => $incidentsQuery->selectRaw('incident_type, count(incident_type) as total')
                 ->groupBy('incident_type')
                 ->pluck('total', 'incident_type'),
-            'roleCount' => $incidents->selectRaw('role, count(role) as total')
+            'roleCount' => $incidentsQuery->selectRaw('role, count(role) as total')
                 ->groupBy('role')
                 ->pluck('total', 'role'),
-            'statusCount' => $incidents->selectRaw('status, count(status) as total')
+            'statusCount' => $incidentsQuery->selectRaw('status, count(status) as total')
                 ->groupBy('status')
                 ->pluck('total', 'status'),
-            'anonymousCount' => $incidents->selectRaw('anonymous, count(anonymous) as total')
+            'anonymousCount' => $incidentsQuery->selectRaw('anonymous, count(anonymous) as total')
                 ->groupBy('anonymous')
                 ->pluck('total', 'anonymous'),
-            'descriptorCount' => $incidents->selectRaw('descriptor, count(descriptor) as total')
+            'descriptorCount' => $incidentsQuery->selectRaw('descriptor, count(descriptor) as total')
                 ->groupBy('descriptor')
                 ->pluck('total', 'descriptor'),
-            'safetyCount' => $incidents->selectRaw('descriptor, count(descriptor) as total')
+            'safetyCount' => $incidentsQuery->selectRaw('descriptor, count(descriptor) as total')
                 ->where('incident_type', IncidentType::SAFETY)
                 ->groupBy('descriptor')
                 ->pluck('total', 'descriptor'),
-            'environmentalCount' => $incidents->selectRaw('descriptor, count(descriptor) as total')
+            'environmentalCount' => $incidentsQuery->selectRaw('descriptor, count(descriptor) as total')
                 ->where('incident_type', IncidentType::ENVIRONMENTAL)
                 ->groupBy('descriptor')
                 ->pluck('total', 'descriptor'),
-            'securityCount' => $incidents->selectRaw('descriptor, count(descriptor) as total')
+            'securityCount' => $incidentsQuery->selectRaw('descriptor, count(descriptor) as total')
                 ->where('incident_type', IncidentType::SECURITY)
                 ->groupBy('descriptor')
                 ->pluck('total', 'descriptor'),
-            'onBehalfCount' => $incidents->selectRaw('on_behalf, count(on_behalf) as total')
+            'onBehalfCount' => $incidentsQuery->selectRaw('on_behalf, count(on_behalf) as total')
                 ->groupBy('on_behalf')
                 ->pluck('total', 'on_behalf'),
-            'onBehalfAnonymousCount' => $incidents->selectRaw('on_behalf_anonymous, count(on_behalf_anonymous) as total')
+            'onBehalfAnonymousCount' => $incidentsQuery->selectRaw('on_behalf_anonymous, count(on_behalf_anonymous) as total')
                 ->groupBy('on_behalf_anonymous')
                 ->pluck('total', 'on_behalf_anonymous'),
 

--- a/resources/js/Pages/Report/Stats.tsx
+++ b/resources/js/Pages/Report/Stats.tsx
@@ -1,14 +1,14 @@
+import DateInput from '@/Components/DateInput';
 import { getIncidentRoleKey } from '@/Enums/IncidentRole';
 import { getIncidentTypeKey } from '@/Enums/IncidentType';
 import classNames from '@/Formatters/classNames';
+import dateFormat from '@/Formatters/dateFormat';
 import { getLocationAcronym } from '@/Helpers/Report/getLocationAcronym';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import Graph from '@/Pages/Report/Partials/Graph';
-import {Head, router} from '@inertiajs/react';
+import { Head, router } from '@inertiajs/react';
+import dayjs from 'dayjs';
 import { useState } from 'react';
-import DateInput from "@/Components/DateInput";
-import dateFormat from "@/Formatters/dateFormat";
-import dayjs from "dayjs";
 
 interface Statistic {
     labels: string[];
@@ -46,10 +46,9 @@ export default function Stats({
     locationCount,
     closedTimeCount,
 }: StatsProps) {
+    const [startDate, setStartDate] = useState((route().queryParams.start as string) ?? dateFormat(dayjs().subtract(1, 'year').toDate()));
 
-    const [startDate, setStartDate] = useState(route().queryParams.start as string ?? dateFormat(dayjs().subtract(1, 'year').toDate()));
-
-    const [endDate, setEndDate] = useState(route().queryParams.end as string ?? dateFormat(dayjs().toDate()));
+    const [endDate, setEndDate] = useState((route().queryParams.end as string) ?? dateFormat(dayjs().toDate()));
 
     const setTimePeriod = (start: string, end: string) => {
         if (dayjs(start).isAfter(dayjs(end))) {
@@ -61,7 +60,7 @@ export default function Stats({
         setStartDate(start);
         setEndDate(end);
 
-        router.get(route('report.stats', { start: start, end: end }))
+        router.get(route('report.stats', { start: start, end: end }));
     };
 
     const statistics: Statistic[] = [
@@ -149,7 +148,7 @@ export default function Stats({
             <Head title="Statistics" />
 
             <div className="mb-10 flex w-full justify-center">
-                <div className='flex w-1/2 gap-5 items-center'>
+                <div className="flex w-1/2 items-center gap-5">
                     <DateInput
                         value={startDate}
                         onChange={(e) => {

--- a/resources/js/Pages/Report/Stats.tsx
+++ b/resources/js/Pages/Report/Stats.tsx
@@ -4,8 +4,11 @@ import classNames from '@/Formatters/classNames';
 import { getLocationAcronym } from '@/Helpers/Report/getLocationAcronym';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import Graph from '@/Pages/Report/Partials/Graph';
-import { Head } from '@inertiajs/react';
+import {Head, router} from '@inertiajs/react';
 import { useState } from 'react';
+import DateInput from "@/Components/DateInput";
+import dateFormat from "@/Formatters/dateFormat";
+import dayjs from "dayjs";
 
 interface Statistic {
     labels: string[];
@@ -43,6 +46,24 @@ export default function Stats({
     locationCount,
     closedTimeCount,
 }: StatsProps) {
+
+    const [startDate, setStartDate] = useState(route().queryParams.start as string ?? dateFormat(dayjs().subtract(1, 'year').toDate()));
+
+    const [endDate, setEndDate] = useState(route().queryParams.end as string ?? dateFormat(dayjs().toDate()));
+
+    const setTimePeriod = (start: string, end: string) => {
+        if (dayjs(start).isAfter(dayjs(end))) {
+            end = dateFormat(dayjs(start).add(1, 'day').toDate());
+        } else if (dayjs(end).isBefore(dayjs(start))) {
+            start = dateFormat(dayjs(end).subtract(1, 'day').toDate());
+        }
+
+        setStartDate(start);
+        setEndDate(end);
+
+        router.get(route('report.stats', { start: start, end: end }))
+    };
+
     const statistics: Statistic[] = [
         {
             labels: Object.keys(locationCount).map(getLocationAcronym),
@@ -126,6 +147,25 @@ export default function Stats({
     return (
         <AuthenticatedLayout>
             <Head title="Statistics" />
+
+            <div className="mb-10 flex w-full justify-center">
+                <div className='flex w-1/2 gap-5 items-center'>
+                    <DateInput
+                        value={startDate}
+                        onChange={(e) => {
+                            setTimePeriod(dateFormat(e.target.value), endDate);
+                        }}
+                    />
+                    <div>to</div>
+                    <DateInput
+                        value={endDate}
+                        onChange={(e) => {
+                            setTimePeriod(startDate, dateFormat(e.target.value));
+                        }}
+                    />
+                </div>
+            </div>
+
             <div className="mx-8 grid grid-cols-1 gap-5 lg:grid-cols-6">
                 {selectedStatistics.map((selectedStatistic, i) => (
                     <div key={i} className={classNames('relative', i < 3 ? 'lg:col-span-2' : 'lg:col-span-3')}>


### PR DESCRIPTION
# Feature Addition

CLOSES #318 

## Summary

Adds a timeframe select to stats page.

## Rationale

In the event we want to see data for a time period we now can.
 
## Design Documentation

N/A

## Changes

- Adds created at on query string for stats page

## Impact

N/A

## Testing

N/A

## Screenshots/Video

![image](https://github.com/user-attachments/assets/af4fdbb0-57ff-4c5f-a6b9-2cbbbba645b6)

## Checklist

- [ ] Code follows the project's coding standards

- [ ] Unit tests covering the new feature have been added

- [ ] All existing tests pass

- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

N/A