### PR TITLE
341 notification messages editable

### DIFF
--- a/app/Enum/NotificationMessageType.php
+++ b/app/Enum/NotificationMessageType.php
@@ -18,5 +18,4 @@ enum NotificationMessageType: string
     case RCA_CREATED = 'rca-created';
     case RCA_RETURNED = 'rca-returned';
     case COMMENT_ADDED = 'comment-added';
-
 }

--- a/app/Enum/NotificationMessageType.php
+++ b/app/Enum/NotificationMessageType.php
@@ -5,4 +5,18 @@ namespace App\Enum;
 enum NotificationMessageType: string
 {
     case INCIDENT_RECEIVED = 'incident-received';
+    case INCIDENT_SUBMITTED = 'incident-submitted';
+    case INCIDENT_ASSIGNED = 'incident-assigned';
+    case INCIDENT_REVIEW_REQUESTED = 'incident-review-requested';
+    case INCIDENT_REVIEW_LATE = 'incident-review-late';
+    case ADDITIONAL_INFORMATION_ADDED = 'additional-information-added';
+    case FILES_UPLOADED = 'files-uploaded';
+    case INCIDENT_CLOSED = 'incident-closed';
+    case INCIDENT_REOPENED = 'incident-reopened';
+    case INVESTIGATION_CREATED = 'investigation-created';
+    case INVESTIGATION_RETURNED = 'investigation-returned';
+    case RCA_CREATED = 'rca-created';
+    case RCA_RETURNED = 'rca-returned';
+    case COMMENT_ADDED = 'comment-added';
+
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -118,8 +118,8 @@ class DashboardController extends Controller
     {
         Gate::authorize('view-settings');
 
-        $incidentReceivedMessage = NotificationMessage::firstWhere('name', 'incident-received');
+        $notificationMessages = NotificationMessage::all();
 
-        return Inertia::render('Dashboard/Settings', ['incidentReceivedMessage' => $incidentReceivedMessage]);
+        return Inertia::render('Dashboard/Settings', ['notificationMessages' => $notificationMessages]);
     }
 }

--- a/app/Models/NotificationMessage.php
+++ b/app/Models/NotificationMessage.php
@@ -19,6 +19,7 @@ class NotificationMessage extends Model
     {
         return [
             'name' => NotificationMessageType::class,
+            'data' => 'array',
         ];
     }
 }

--- a/app/Notifications/BaseNotification.php
+++ b/app/Notifications/BaseNotification.php
@@ -2,6 +2,8 @@
 
 namespace App\Notifications;
 
+use App\Enum\NotificationMessageType;
+use App\Models\NotificationMessage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -10,6 +12,7 @@ abstract class BaseNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
+    public array $data;
     public string $message;
     public string $url;
 
@@ -35,5 +38,21 @@ abstract class BaseNotification extends Notification implements ShouldQueue
             'url' => $this->url,
             'message' => $this->message,
         ];
+    }
+
+    /**
+     * Parse the notification message and replace with the placeholders with the data from $data array.
+     * Assign the parsed message to $this->message
+     *
+     * @return void
+     */
+    public function parseMessage(NotificationMessageType $notificationMessageType)
+    {
+        $notificationMessage = NotificationMessage::firstWhere('name', $notificationMessageType->value);
+
+        $this->message = preg_replace_callback('/\{(\w+)}/', function ($matches) {
+            $key = $matches[1];
+            return $this->data[$key] ?? $matches[0];
+        }, $notificationMessage->message);
     }
 }

--- a/app/Notifications/BaseNotification.php
+++ b/app/Notifications/BaseNotification.php
@@ -41,7 +41,7 @@ abstract class BaseNotification extends Notification implements ShouldQueue
     }
 
     /**
-     * Parse the notification message and replace with the placeholders with the data from $data array.
+     * Parse the notification message and replace the placeholders with the data from $data array.
      * Assign the parsed message to $this->message
      *
      * @return void

--- a/app/Notifications/BaseNotification.php
+++ b/app/Notifications/BaseNotification.php
@@ -44,6 +44,7 @@ abstract class BaseNotification extends Notification implements ShouldQueue
      * Parse the notification message and replace the placeholders with the data from $data array.
      * Assign the parsed message to $this->message
      *
+     * @param NotificationMessageType $notificationMessageType
      * @return void
      */
     public function parseMessage(NotificationMessageType $notificationMessageType)

--- a/app/Notifications/Comment/CommentAdded.php
+++ b/app/Notifications/Comment/CommentAdded.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\Comment;
 
+use App\Enum\NotificationMessageType;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -15,12 +16,10 @@ class CommentAdded extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $comment,
-        public User $user,
         public string $url,
-        public string $incidentSlug,
+        public array $data,
     ) {
-        $this->message = "$user->name commented on incident #$incidentSlug: $comment";
+        $this->parseMessage(NotificationMessageType::COMMENT_ADDED);
     }
 
     /**
@@ -29,12 +28,10 @@ class CommentAdded extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Comment Created')
+            ->subject("Comment Added on Incident #{$this->data['incidentSlug']}")
             ->line($this->message)
             ->markdown('mail.comment-made', [
-                'incidentSlug' => $this->incidentSlug,
-                'commenter' => $this->user->name,
-                'content' => $this->comment,
+                'message' => $this->message,
                 'url' => $this->url,
             ]);
     }

--- a/app/Notifications/Comment/CommentAdded.php
+++ b/app/Notifications/Comment/CommentAdded.php
@@ -3,7 +3,6 @@
 namespace App\Notifications\Comment;
 
 use App\Enum\NotificationMessageType;
-use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use App\Notifications\BaseNotification;

--- a/app/Notifications/Incident/AdditionalInformationNotification.php
+++ b/app/Notifications/Incident/AdditionalInformationNotification.php
@@ -2,15 +2,16 @@
 
 namespace App\Notifications\Incident;
 
+use App\Enum\NotificationMessageType;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 
 class AdditionalInformationNotification extends BaseNotification
 {
-    public function __construct(public string $incidentSlug, public string $additionalInformation)
+    public function __construct(public array $data)
     {
-        $this->url = route('incidents.show', ['incident' => $this->incidentSlug]);
-        $this->message = "Additional information was added to incident# $this->incidentSlug";
+        $this->url = route('incidents.show', ['incident' => $this->data['incidentSlug']]);
+        $this->parseMessage(NotificationMessageType::ADDITIONAL_INFORMATION_ADDED);
     }
 
     /**
@@ -19,11 +20,10 @@ class AdditionalInformationNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Additional Information Added To Incident #$this->incidentSlug")
+            ->subject("Additional Information Added To Incident #{$this->data['incidentSlug']}")
             ->markdown('mail.incident-additional-information', [
                 'url' => $this->url,
-                'incidentSlug' => $this->incidentSlug,
-                'additionalInformation' => $this->additionalInformation,
+                'message' => $this->message,
             ]);
     }
 }

--- a/app/Notifications/Incident/FilesUploadedNotification.php
+++ b/app/Notifications/Incident/FilesUploadedNotification.php
@@ -3,7 +3,6 @@
 namespace App\Notifications\Incident;
 
 use App\Enum\NotificationMessageType;
-use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 

--- a/app/Notifications/Incident/FilesUploadedNotification.php
+++ b/app/Notifications/Incident/FilesUploadedNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\Incident;
 
+use App\Enum\NotificationMessageType;
 use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -12,11 +13,10 @@ class FilesUploadedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentSlug,
-        public User   $user
+        public array $data,
     ) {
-        $this->message = "{$this->user->name} has uploaded files to incident #$incidentSlug.";
-        $this->url = route('incidents.show', ['incident' => $incidentSlug]);
+        $this->url = route('incidents.show', ['incident' => $this->data['incidentSlug']]);
+        $this->parseMessage(NotificationMessageType::FILES_UPLOADED);
     }
 
     /**
@@ -35,7 +35,7 @@ class FilesUploadedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Files Have Been Uploaded to Incident #$this->incidentSlug")
+            ->subject("Files Have Been Uploaded to Incident #{$this->data['incidentSlug']}")
             ->markdown('mail.files-uploaded-notification', [
                 'url' => $this->url,
                 'message' => $this->message

--- a/app/Notifications/Incident/IncidentClosedNotification.php
+++ b/app/Notifications/Incident/IncidentClosedNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\Incident;
 
+use App\Enum\NotificationMessageType;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 
@@ -11,10 +12,10 @@ class IncidentClosedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentSlug,
+        public array $data
     ) {
-        $this->message = "Incident #$incidentSlug has been closed";
-        $this->url = route('incidents.show', ['incident' => $this->incidentSlug]);
+        $this->url = route('incidents.show', ['incident' => $this->data['incidentSlug']]);
+        $this->parseMessage(NotificationMessageType::INCIDENT_CLOSED);
     }
 
     /**
@@ -33,7 +34,7 @@ class IncidentClosedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Incident #$this->incidentSlug Closed")
+            ->subject("Incident #{$this->data['incidentSlug']} Closed")
             ->markdown('mail.incident-closed-notification', [
                 'url' => $this->url,
                 'message' => $this->message

--- a/app/Notifications/Incident/IncidentFollowUpOverdueNotification.php
+++ b/app/Notifications/Incident/IncidentFollowUpOverdueNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\Incident;
 
+use App\Enum\NotificationMessageType;
 use App\Models\Incident;
 use App\Models\User;
 use App\Notifications\BaseNotification;
@@ -19,11 +20,10 @@ class IncidentFollowUpOverdueNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentSlug,
-        public User   $supervisor,
+        public array $data,
     ) {
-        $this->message = "Your required follow-up on incident #$incidentSlug is overdue.";
-        $this->url = route('incidents.show', ['incident' => $incidentSlug]);
+        $this->url = route('incidents.show', ['incident' => $this->data['incidentSlug']]);
+        $this->parseMessage(NotificationMessageType::INCIDENT_REVIEW_LATE);
     }
 
     /**
@@ -44,9 +44,9 @@ class IncidentFollowUpOverdueNotification extends BaseNotification
      */
     public function shouldSend(object $notifiable, string $channel): bool
     {
-        $incident = Incident::where('slug', $this->incidentSlug)->first();
+        $incident = Incident::where('slug', $this->data['incidentSlug'])->first();
         return ($incident->status::class == Assigned::class || $incident->status::class == Returned::class)
-            && $incident->supervisor_id == $this->supervisor->id;
+            && $incident->supervisor_id == $this->data['supervisorId'];
     }
 
     /**
@@ -55,7 +55,7 @@ class IncidentFollowUpOverdueNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Incident #$this->incidentSlug Follow Up Overdue")
+            ->subject("Incident #{$this->data['incidentSlug']} Follow Up Overdue")
             ->markdown('mail.incident-follow-up-overdue-notification', [
                 'url' => $this->url,
                 'message' => $this->message

--- a/app/Notifications/Incident/IncidentFollowUpOverdueNotification.php
+++ b/app/Notifications/Incident/IncidentFollowUpOverdueNotification.php
@@ -4,7 +4,6 @@ namespace App\Notifications\Incident;
 
 use App\Enum\NotificationMessageType;
 use App\Models\Incident;
-use App\Models\User;
 use App\Notifications\BaseNotification;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\Returned;

--- a/app/Notifications/Incident/IncidentReopenedNotification.php
+++ b/app/Notifications/Incident/IncidentReopenedNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\Incident;
 
+use App\Enum\NotificationMessageType;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\VonageMessage;
@@ -12,10 +13,10 @@ class IncidentReopenedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentSlug,
+        public array $data,
     ) {
-        $this->message = "Incident #{$incidentSlug} has been reopened.";
-        $this->url = route('incidents.show', ['incident' => $incidentSlug]);
+        $this->url = route('incidents.show', ['incident' => $this->data['incidentSlug']]);
+        $this->parseMessage(NotificationMessageType::INCIDENT_REOPENED);
     }
 
     /**
@@ -43,7 +44,7 @@ class IncidentReopenedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Incident $this->incidentSlug Reopened")
+            ->subject("Incident {$this->data['incidentSlug']} Reopened")
             ->line($this->message)
             ->markdown('mail.incident-reopened-notification', [
                 'url' => $this->url,

--- a/app/Notifications/Incident/IncidentReviewRequestNotification.php
+++ b/app/Notifications/Incident/IncidentReviewRequestNotification.php
@@ -2,7 +2,7 @@
 
 namespace App\Notifications\Incident;
 
-use App\Models\User;
+use App\Enum\NotificationMessageType;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 
@@ -12,11 +12,10 @@ class IncidentReviewRequestNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentSlug,
-        public User   $supervisor,
+        public array $data
     ) {
-        $this->message = "{$this->supervisor->name} has requested follow-up review on incident #$incidentSlug.";
-        $this->url = route('incidents.show', ['incident' => $incidentSlug]);
+        $this->url = route('incidents.show', ['incident' => $this->data['incidentSlug']]);
+        $this->parseMessage(NotificationMessageType::INCIDENT_REVIEW_REQUESTED);
     }
 
     /**
@@ -25,7 +24,7 @@ class IncidentReviewRequestNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Incident #$this->incidentSlug Follow Up Review Request")
+            ->subject("Incident #{$this->data['incidentSlug']} Follow Up Review Request")
             ->markdown('mail.incident-review-request', [
                 'url' => $this->url,
                 'message' => $this->message

--- a/app/Notifications/Incident/IncidentSubmittedNotification.php
+++ b/app/Notifications/Incident/IncidentSubmittedNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\Incident;
 
+use App\Enum\NotificationMessageType;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Messages\VonageMessage;
@@ -12,23 +13,13 @@ class IncidentSubmittedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string  $incidentId,
-        public ?string $firstName,
-        public ?string $lastName,
+        public array $data,
     ) {
-        if ($firstName == null && $lastName == null) {
-            $name = 'an Anonymous User';
-        } elseif ($firstName == null) {
-            $name = $lastName;
-        } elseif ($lastName == null) {
-            $name = $firstName;
-        } else {
-            $name = $firstName . ' ' . $lastName;
-        }
-        $this->message = "An incident was submitted by $name";
         $this->url = route('incidents.show', [
-            'incident' => $incidentId,
+            'incident' => $this->data['incidentId'],
         ]);
+
+        $this->parseMessage(NotificationMessageType::INCIDENT_SUBMITTED);
     }
 
     /**

--- a/app/Notifications/Incident/SupervisorAssignedNotification.php
+++ b/app/Notifications/Incident/SupervisorAssignedNotification.php
@@ -2,7 +2,7 @@
 
 namespace App\Notifications\Incident;
 
-use App\Models\User;
+use App\Enum\NotificationMessageType;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 
@@ -12,12 +12,10 @@ class SupervisorAssignedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentSlug,
-        public User   $supervisor,
-        public User   $admin,
+        public array $data
     ) {
-        $this->url = route('incidents.show', ['incident' => $incidentSlug]);
-        $this->message = "$admin->name has assigned you to incident #$incidentSlug.";
+        $this->url = route('incidents.show', ['incident' => $this->data['incidentSlug']]);
+        $this->parseMessage(NotificationMessageType::INCIDENT_ASSIGNED);
     }
 
     /**
@@ -26,12 +24,10 @@ class SupervisorAssignedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Incident #$this->incidentSlug Assigned")
+            ->subject("Incident #{$this->data['incidentSlug']} Assigned")
             ->markdown('mail.incident-assigned', [
                 'url' => $this->url,
-                'supervisorName' => $this->supervisor->name,
-                'adminName' => $this->admin->name,
-                'incidentSlug' => $this->incidentSlug,
+                'message' => $this->message,
             ]);
     }
 }

--- a/app/Notifications/Investigation/InvestigationReturnedNotification.php
+++ b/app/Notifications/Investigation/InvestigationReturnedNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\Investigation;
 
+use App\Enum\NotificationMessageType;
 use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -12,15 +13,14 @@ class InvestigationReturnedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentSlug,
-        public string $investigationId,
-        public User   $admin
+        public array $data
     ) {
-        $this->message = "$admin->name has returned your investigation on incident #$incidentSlug for further review";
         $this->url = route('incidents.investigations.show', [
-            'incident' => $incidentSlug,
-            'investigation' => $investigationId
+            'incident' => $this->data['incidentSlug'],
+            'investigation' => $this->data['investigationId']
         ]);
+
+        $this->parseMessage(NotificationMessageType::INVESTIGATION_RETURNED);
     }
 
     /**
@@ -29,7 +29,7 @@ class InvestigationReturnedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Investigation For Incident #$this->incidentSlug Returned")
+            ->subject("Investigation For Incident #{$this->data['incidentSlug']} Returned")
             ->markdown('mail.investigation-returned', [
                 'url' => $this->url,
                 'message' => $this->message

--- a/app/Notifications/Investigation/InvestigationReturnedNotification.php
+++ b/app/Notifications/Investigation/InvestigationReturnedNotification.php
@@ -3,7 +3,6 @@
 namespace App\Notifications\Investigation;
 
 use App\Enum\NotificationMessageType;
-use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 

--- a/app/Notifications/Investigation/InvestigationSubmittedNotification.php
+++ b/app/Notifications/Investigation/InvestigationSubmittedNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\Investigation;
 
+use App\Enum\NotificationMessageType;
 use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -12,15 +13,14 @@ class InvestigationSubmittedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentSlug,
-        public string $investigationId,
-        public User   $supervisor,
+        public array $data
     ) {
-        $this->message = "A new investigation for incident #$incidentSlug was submitted by $supervisor->name";
         $this->url = route('incidents.investigations.show', [
-            'incident' => $incidentSlug,
-            'investigation' => $investigationId
+            'incident' => $this->data['incidentSlug'],
+            'investigation' => $this->data['investigationId']
         ]);
+
+        $this->parseMessage(NotificationMessageType::INVESTIGATION_CREATED);
     }
 
     /**
@@ -29,7 +29,7 @@ class InvestigationSubmittedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Investigation Submitted For Incident #$this->incidentSlug")
+            ->subject("Investigation Submitted For Incident #{$this->data['incidentSlug']}")
             ->markdown('mail.investigation-submitted', [
                 'url' => $this->url,
                 'message' => $this->message

--- a/app/Notifications/Investigation/InvestigationSubmittedNotification.php
+++ b/app/Notifications/Investigation/InvestigationSubmittedNotification.php
@@ -3,7 +3,6 @@
 namespace App\Notifications\Investigation;
 
 use App\Enum\NotificationMessageType;
-use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 

--- a/app/Notifications/RootCauseAnalysis/RootCauseAnalysisReturnedNotification.php
+++ b/app/Notifications/RootCauseAnalysis/RootCauseAnalysisReturnedNotification.php
@@ -2,7 +2,7 @@
 
 namespace App\Notifications\RootCauseAnalysis;
 
-use App\Models\User;
+use App\Enum\NotificationMessageType;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 
@@ -12,15 +12,14 @@ class RootCauseAnalysisReturnedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentSlug,
-        public string $rootCauseAnalysisId,
-        public User $admin
+        public array $data,
     ) {
-        $this->message = "$admin->name has returned your root cause analysis on incident #$incidentSlug for further review";
         $this->url = route('incidents.root-cause-analyses.show', [
-            'incident' => $this->incidentSlug,
-            'root_cause_analysis' => $this->rootCauseAnalysisId
+            'incident' => $this->data['incidentSlug'],
+            'root_cause_analysis' => $this->data['rootCauseAnalysisId'],
         ]);
+
+        $this->parseMessage(NotificationMessageType::RCA_RETURNED);
     }
 
     /**
@@ -39,7 +38,7 @@ class RootCauseAnalysisReturnedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject('Root Cause Analysis Returned')
+            ->subject("Root Cause Analysis For Incident #{$this->data['incidentSlug']} Returned")
             ->markdown('mail.root-cause-analysis-returned', [
                 'url' => $this->url,
                 'message' => $this->message,

--- a/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
+++ b/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
@@ -3,7 +3,6 @@
 namespace App\Notifications\RootCauseAnalysis;
 
 use App\Enum\NotificationMessageType;
-use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 

--- a/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
+++ b/app/Notifications/RootCauseAnalysis/RootCauseAnalysisSubmittedNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications\RootCauseAnalysis;
 
+use App\Enum\NotificationMessageType;
 use App\Models\User;
 use App\Notifications\BaseNotification;
 use Illuminate\Notifications\Messages\MailMessage;
@@ -12,16 +13,14 @@ class RootCauseAnalysisSubmittedNotification extends BaseNotification
      * Create a new notification instance.
      */
     public function __construct(
-        public string $incidentSlug,
-        public string $rootCauseAnalysisId,
-        public User   $supervisor,
+        public array $data,
     ) {
-        $this->message = "A new root cause analysis for incident #$incidentSlug was submitted by $supervisor->name";
         $this->url = route('incidents.root-cause-analyses.show', [
-            'incident' => $incidentSlug,
-            'root_cause_analysis' => $rootCauseAnalysisId
+            'incident' => $this->data['incidentSlug'],
+            'root_cause_analysis' => $this->data['rootCauseAnalysisId'],
         ]);
 
+        $this->parseMessage(NotificationMessageType::RCA_CREATED);
     }
 
     /**
@@ -30,7 +29,7 @@ class RootCauseAnalysisSubmittedNotification extends BaseNotification
     public function toMail(object $notifiable): MailMessage
     {
         return (new MailMessage)
-            ->subject("Root Cause Analysis Submitted For Incident #$this->incidentSlug")
+            ->subject("Root Cause Analysis Submitted For Incident #{$this->data['incidentSlug']}")
             ->markdown('mail.root-cause-analysis-submitted', ['url' => $this->url, 'message' => $this->message]);
     }
 }

--- a/app/StorableEvents/Comment/CommentCreated.php
+++ b/app/StorableEvents/Comment/CommentCreated.php
@@ -41,7 +41,12 @@ class CommentCreated extends StoredEvent
         if ($commentable) {
             $url = route('incidents.show', ['incident' => $this->commentable_id]);
 
-            $notification = new CommentAdded($this->content, $commenter, $url, $commentable->slug);
+            $data = [
+                'name' => $commenter->name,
+                'incidentSlug' => $commentable->slug,
+                'comment' => $this->content,
+            ];
+            $notification = new CommentAdded($url, $data);
 
             if ($commentable->supervisor && $commentable->supervisor->id !== $this->metaData['user_id']) {
                 Notification::send($commentable->supervisor, $notification);

--- a/app/StorableEvents/Incident/AdditionalInformationAdded.php
+++ b/app/StorableEvents/Incident/AdditionalInformationAdded.php
@@ -62,6 +62,10 @@ class AdditionalInformationAdded extends StoredEvent
         $admins = User::role('admin')->get();
         $incident = $this->incident();
 
-        Notification::send($admins, new AdditionalInformationNotification($incident->slug, $this->additionalInformation));
+        $data = [
+            'incidentSlug' => $incident->slug
+        ];
+
+        Notification::send($admins, new AdditionalInformationNotification($data));
     }
 }

--- a/app/StorableEvents/Incident/FilesUploaded.php
+++ b/app/StorableEvents/Incident/FilesUploaded.php
@@ -45,6 +45,11 @@ class FilesUploaded extends StoredEvent
 
         $incident = $this->incident();
 
-        Notification::send($admins, new FilesUploadedNotification($incident->slug, $supervisor));
+        $data = [
+            'incidentSlug' => $incident->slug,
+            'name' => $supervisor->name,
+        ];
+
+        Notification::send($admins, new FilesUploadedNotification($data));
     }
 }

--- a/app/StorableEvents/Incident/IncidentClosed.php
+++ b/app/StorableEvents/Incident/IncidentClosed.php
@@ -50,11 +50,16 @@ class IncidentClosed extends StoredEvent
     {
         $incident = $this->incident();
 
+        $data = [
+            'incidentSlug' => $incident->slug,
+        ];
+
         if ($incident->supervisor) {
-            Notification::send($incident->supervisor, new IncidentClosedNotification($incident->id));
+            Notification::send($incident->supervisor, new IncidentClosedNotification($data));
         }
 
         $admins = User::role('admin')->get();
-        Notification::send($admins, new IncidentClosedNotification($incident->slug));
+
+        Notification::send($admins, new IncidentClosedNotification($data));
     }
 }

--- a/app/StorableEvents/Incident/IncidentCreated.php
+++ b/app/StorableEvents/Incident/IncidentCreated.php
@@ -93,6 +93,21 @@ class IncidentCreated extends StoredEvent
 
         $admins = User::role('admin')->get();
 
-        Notification::send($admins, new IncidentSubmittedNotification($this->aggregateRootUuid(), $this->first_name, $this->last_name));
+        if ($this->first_name == null && $this->last_name == null) {
+            $name = 'an Anonymous User';
+        } elseif ($this->first_name == null) {
+            $name = $this->last_name;
+        } elseif ($this->last_name == null) {
+            $name = $this->first_name;
+        } else {
+            $name = $this->first_name . ' ' . $this->last_name;
+        }
+
+        $data = [
+            'incidentId' => $this->aggregateRootUuid(),
+            'name' => $name,
+        ];
+
+        Notification::send($admins, new IncidentSubmittedNotification($data));
     }
 }

--- a/app/StorableEvents/Incident/IncidentReopened.php
+++ b/app/StorableEvents/Incident/IncidentReopened.php
@@ -51,6 +51,11 @@ class IncidentReopened extends StoredEvent
     {
         $incident = $this->incident();
         $admins = User::role('admin')->get();
-        Notification::send($admins, new IncidentReopenedNotification($incident->slug));
+
+        $data = [
+            'incidentSlug' => $incident->slug
+        ];
+
+        Notification::send($admins, new IncidentReopenedNotification($data));
     }
 }

--- a/app/StorableEvents/Incident/IncidentReviewRequested.php
+++ b/app/StorableEvents/Incident/IncidentReviewRequested.php
@@ -54,6 +54,11 @@ class IncidentReviewRequested extends StoredEvent
 
         $incident = $this->incident();
 
-        Notification::send($admins, new IncidentReviewRequestNotification($incident->slug, $supervisor));
+        $data = [
+            'incidentSlug' => $incident->slug,
+            'name' => $supervisor->name,
+        ];
+
+        Notification::send($admins, new IncidentReviewRequestNotification($data));
     }
 }

--- a/app/StorableEvents/Incident/SupervisorAssigned.php
+++ b/app/StorableEvents/Incident/SupervisorAssigned.php
@@ -69,8 +69,19 @@ class SupervisorAssigned extends StoredEvent
         $admin = User::find($this->metaData['user_id']);
         $incident = $this->incident();
 
-        Notification::send($this->supervisor(), new SupervisorAssignedNotification($incident->slug, $this->supervisor(), $admin));
+        $assignedData = [
+            'incidentSlug' => $incident->slug,
+            'name' => $admin->name,
+        ];
 
-        Notification::send($this->supervisor(), new IncidentFollowUpOverdueNotification($incident->slug, $this->supervisor()));
+        Notification::send($this->supervisor(), new SupervisorAssignedNotification($assignedData));
+
+        $overdueData = [
+            'incidentSlug' => $incident->slug,
+            'name' => $this->supervisor()->name,
+            'supervisorId' => $this->supervisor_id,
+        ];
+
+        Notification::send($this->supervisor(), new IncidentFollowUpOverdueNotification($overdueData));
     }
 }

--- a/app/StorableEvents/Investigation/InvestigationCreated.php
+++ b/app/StorableEvents/Investigation/InvestigationCreated.php
@@ -91,6 +91,12 @@ class InvestigationCreated extends StoredEvent
         $supervisor = User::find($this->metaData['user_id']);
         $incident = $this->incident();
 
-        Notification::send($admins, new InvestigationSubmittedNotification($incident->slug, $this->aggregateRootUuid(), $supervisor));
+        $data = [
+            'incidentSlug' => $incident->slug,
+            'investigationId' => $this->aggregateRootUuid(),
+            'name' => $supervisor->name,
+        ];
+
+        Notification::send($admins, new InvestigationSubmittedNotification($data));
     }
 }

--- a/app/StorableEvents/Investigation/InvestigationReturned.php
+++ b/app/StorableEvents/Investigation/InvestigationReturned.php
@@ -54,6 +54,12 @@ class InvestigationReturned extends StoredEvent
         $incident = $this->incident();
         $investigation = Investigation::where('incident_id', $this->aggregateRootUuid())->first();
 
-        Notification::send($investigation->supervisor, new InvestigationReturnedNotification($incident->slug, $investigation->id, $admin));
+        $data = [
+          'incidentSlug' => $incident->slug,
+          'investigationId' => $investigation->id,
+          'name' => $admin->name,
+        ];
+
+        Notification::send($investigation->supervisor, new InvestigationReturnedNotification($data));
     }
 }

--- a/app/StorableEvents/RootCauseAnalysis/RootCauseAnalysisCreated.php
+++ b/app/StorableEvents/RootCauseAnalysis/RootCauseAnalysisCreated.php
@@ -93,8 +93,13 @@ class RootCauseAnalysisCreated extends StoredEvent
         $admins = User::role('admin')->get();
 
         $supervisor = User::find($this->metaData['user_id']);
-        $incident = $this->incident();
 
-        Notification::send($admins, new RootCauseAnalysisSubmittedNotification($incident->slug, $this->aggregateRootUuid(), $supervisor));
+        $data = [
+            'incidentSlug' => $this->incident()->slug,
+            'rootCauseAnalysisId' => $this->aggregateRootUuid(),
+            'name' => $supervisor->name,
+        ];
+
+        Notification::send($admins, new RootCauseAnalysisSubmittedNotification($data));
     }
 }

--- a/app/StorableEvents/RootCauseAnalysis/RootCauseAnalysisReturned.php
+++ b/app/StorableEvents/RootCauseAnalysis/RootCauseAnalysisReturned.php
@@ -51,9 +51,14 @@ class RootCauseAnalysisReturned extends StoredEvent
     public function react(): void
     {
         $admin = User::find($this->metaData['user_id']);
-        $incident = $this->incident();
         $rca = RootCauseAnalysis::where('incident_id', $this->aggregateRootUuid())->first();
 
-        Notification::send($rca->supervisor, new RootCauseAnalysisReturnedNotification($incident->slug, $rca->id, $admin));
+        $data = [
+            'incidentSlug' => $this->incident()->slug,
+            'rootCauseAnalysisId' => $rca->id,
+            'name' => $admin->name,
+        ];
+
+        Notification::send($rca->supervisor, new RootCauseAnalysisReturnedNotification($data));
     }
 }

--- a/database/migrations/2025_03_14_120507_add_data_to_notification_messages_table.php
+++ b/database/migrations/2025_03_14_120507_add_data_to_notification_messages_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2025_03_14_120507_add_data_to_notification_messages_table.php
+++ b/database/migrations/2025_03_14_120507_add_data_to_notification_messages_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('notification_messages', function (Blueprint $table) {
+            $table->jsonb('data');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('notification_messages', function (Blueprint $table) {
+            $table->dropColumn('data');
+        });
+    }
+};

--- a/database/seeders/NotificationMessageSeeder.php
+++ b/database/seeders/NotificationMessageSeeder.php
@@ -13,15 +13,77 @@ class NotificationMessageSeeder extends Seeder
      */
     public function run(): void
     {
-        $incidentReceivedMessage = NotificationMessage::firstOrNew([
-            'name' => NotificationMessageType::INCIDENT_RECEIVED,
-        ]);
+        $initialMessages = [
+            NotificationMessageType::INCIDENT_RECEIVED->value => [
+                'message' => 'Thank you for submitting this incident report. HSE may reach out to you for follow-up or additional questions. You may add any additional information to this file by clicking the below link:',
+                'data' => []
+            ],
+            NotificationMessageType::INCIDENT_SUBMITTED->value => [
+                'message' => 'An incident was submitted by {name}.',
+                'data' => ['name']
+            ],
+            NotificationMessageType::INCIDENT_ASSIGNED->value => [
+                'message' => '{name} has assigned you to incident #{incidentSlug}.',
+                'data' => ['name', 'incidentSlug']
+            ],
+            NotificationMessageType::INCIDENT_REVIEW_REQUESTED->value => [
+                'message' => '{name} has requested follow-up review on incident #{incidentSlug}.',
+                'data' => ['name', 'incidentSlug']
+            ],
+            NotificationMessageType::INCIDENT_REVIEW_LATE->value => [
+                'message' => 'Your required follow-up on incident #{incidentSlug} is overdue.',
+                'data' => ['incidentSlug']
+            ],
+            NotificationMessageType::ADDITIONAL_INFORMATION_ADDED->value => [
+                'message' => 'Additional information was added to incident {incidentSlug}.',
+                'data' => ['incidentSlug']
+            ],
+            NotificationMessageType::FILES_UPLOADED->value => [
+                'message' => '{name} has uploaded files to incident #{incidentSlug}.',
+                'data' => ['name', 'incidentSlug']
+            ],
+            NotificationMessageType::INCIDENT_CLOSED->value => [
+                'message' => 'Incident #{incidentSlug} has been closed.',
+                'data' => ['incidentSlug']
+            ],
+            NotificationMessageType::INCIDENT_REOPENED->value => [
+                'message' => 'Incident #{incidentSlug} has been reopened.',
+                'data' => ['incidentSlug']
+            ],
+            NotificationMessageType::INVESTIGATION_CREATED->value => [
+                'message' => 'A new investigation for incident #{incidentSlug} was submitted by {name}.',
+                'data' => ['name', 'incidentSlug']
+            ],
+            NotificationMessageType::INVESTIGATION_RETURNED->value => [
+                'message' => '{name} has returned your investigation on incident #{incidentSlug} for further review.',
+                'data' => ['name', 'incidentSlug']
+            ],
+            NotificationMessageType::RCA_CREATED->value => [
+                'message' => 'A new Root Cause Analysis for incident #{incidentSlug} was submitted by {name}.',
+                'data' => ['name', 'incidentSlug']
+            ],
+            NotificationMessageType::RCA_RETURNED->value => [
+                'message' => '{name} has returned your Root Cause Analysis on incident #{incidentSlug} for further review.',
+                'data' => ['name', 'incidentSlug']
+            ],
+            NotificationMessageType::COMMENT_ADDED->value => [
+                'message' => '{name} commented on incident #{incidentSlug}: {comment}.',
+                'data' => ['name', 'incidentSlug', 'comment']
+            ],
+        ];
 
-        if (!$incidentReceivedMessage->exists) {
-            $incidentReceivedMessage->message =
-                'Thank you for submitting this incident report. HSE may reach out to you for follow up or additional questions. You may add any additional information to this file by clicking the below link:';
+
+        foreach ($initialMessages as $notificationName => $initialMessage) {
+            $notificationMessage = NotificationMessage::firstOrNew([
+                'name' => $notificationName,
+            ]);
+
+            if (! $notificationMessage->exists) {
+                $notificationMessage->message = $initialMessage['message'];
+                $notificationMessage->data = $initialMessage['data'];
+            }
+
+            $notificationMessage->save();
         }
-
-        $incidentReceivedMessage->save();
     }
 }

--- a/resources/js/Pages/Dashboard/Settings.tsx
+++ b/resources/js/Pages/Dashboard/Settings.tsx
@@ -4,34 +4,40 @@ import InputLabel from '@/Components/InputLabel';
 import LoadingIndicator from '@/Components/LoadingIndicator';
 import PrimaryButton from '@/Components/PrimaryButton';
 import TextArea from '@/Components/TextArea';
+import { uppercaseWordFormat } from '@/Formatters/uppercaseWordFormat';
 import Authenticated from '@/Layouts/AuthenticatedLayout';
 import { NotificationMessage } from '@/types/notification/NotificationMessage';
 import { Head, router, useForm } from '@inertiajs/react';
 import { useState } from 'react';
 
-export default function Settings({ incidentReceivedMessage }: { incidentReceivedMessage: NotificationMessage }) {
+export default function Settings({ notificationMessages }: { notificationMessages: NotificationMessage[] }) {
     const { data, setData, put, processing, errors, cancel, clearErrors } = useForm({
-        message: incidentReceivedMessage.message,
+        message: '',
     });
 
-    const [isEditingIncidentReceivedMessage, setIsEditingIncidentReceivedMessage] = useState(false);
+    const [notificationBeingEdited, setNotificationBeingEdited] = useState<NotificationMessage | null>(null);
 
-    const handleUpdateIncidentReceivedMessage = () => {
-        put(route('notifications.update-message', { notification_message: incidentReceivedMessage.id }), {
+    const handleNotificationBeingEditied = (notificationMessage: NotificationMessage) => {
+        setNotificationBeingEdited(notificationMessage);
+        setData('message', notificationMessage.message);
+    };
+
+    const handleUpdateNotificationMessage = (notificationMessage: NotificationMessage) => {
+        put(route('notifications.update-message', { notification_message: notificationMessage.id }), {
             onSuccess: () => {
-                setIsEditingIncidentReceivedMessage(false);
-                router.reload({ only: ['incidentReceivedMessage'] });
+                setNotificationBeingEdited(null);
+                router.reload({ only: ['notificationMessages'] });
             },
         });
     };
 
-    const handleCancelUpdateIncidentReceivedMessage = () => {
+    const handleCancelUpdateNotificationMessage = () => {
         if (processing) {
             cancel();
         }
 
-        setIsEditingIncidentReceivedMessage(false);
-        setData('message', incidentReceivedMessage.message);
+        setNotificationBeingEdited(null);
+        setData('message', '');
         clearErrors();
     };
 
@@ -41,29 +47,37 @@ export default function Settings({ incidentReceivedMessage }: { incidentReceived
             <div className="px-4 sm:px-6 lg:px-8">
                 <div className="pb-2 text-lg font-semibold text-gray-800">Settings</div>
                 <div className="rounded-md bg-white p-6 shadow-xs ring-1 ring-gray-900/5 sm:rounded-lg">
-                    <div className="space-y-2 p-2">
-                        <div className="font-semibold text-gray-900">Incident Received Message</div>
-                        <InputLabel>Update the content of the incident received notification.</InputLabel>
-                        <TextArea
-                            disabled={processing || !isEditingIncidentReceivedMessage}
-                            value={data.message}
-                            onChange={(e) => setData('message', e.target.value)}
-                        />
-                        <InputError message={errors.message} />
+                    {notificationMessages.map((notificationMessage, i) => (
+                        <div key={i} className="space-y-2 p-2">
+                            <div className="font-semibold text-gray-900">{uppercaseWordFormat(notificationMessage.name, '-')} Message</div>
+                            <InputLabel>Update the content of the {uppercaseWordFormat(notificationMessage.name, '-')} notification.</InputLabel>
+                            {notificationMessage.data.length > 0 && (
+                                <InputLabel>
+                                    <span className={'font-semibold'}>Available Variables: </span>
+                                    <span>{notificationMessage.data.join(', ')}</span>
+                                </InputLabel>
+                            )}
+                            <TextArea
+                                disabled={processing || notificationBeingEdited?.id !== notificationMessage.id}
+                                value={notificationBeingEdited?.id === notificationMessage.id ? data.message : notificationMessage.message}
+                                onChange={(e) => setData('message', e.target.value)}
+                            />
+                            <InputError message={errors.message} />
 
-                        {processing ? (
-                            <LoadingIndicator />
-                        ) : isEditingIncidentReceivedMessage ? (
-                            <div className="flex justify-between">
-                                <DangerButton onClick={handleCancelUpdateIncidentReceivedMessage}>Cancel</DangerButton>
-                                <PrimaryButton disabled={processing} onClick={handleUpdateIncidentReceivedMessage}>
-                                    Update
-                                </PrimaryButton>
-                            </div>
-                        ) : (
-                            <PrimaryButton onClick={() => setIsEditingIncidentReceivedMessage(true)}>Edit</PrimaryButton>
-                        )}
-                    </div>
+                            {processing ? (
+                                <LoadingIndicator />
+                            ) : notificationBeingEdited?.id === notificationMessage.id ? (
+                                <div className="flex justify-between">
+                                    <DangerButton onClick={handleCancelUpdateNotificationMessage}>Cancel</DangerButton>
+                                    <PrimaryButton disabled={processing} onClick={() => handleUpdateNotificationMessage(notificationMessage)}>
+                                        Update
+                                    </PrimaryButton>
+                                </div>
+                            ) : (
+                                <PrimaryButton onClick={() => handleNotificationBeingEditied(notificationMessage)}>Edit</PrimaryButton>
+                            )}
+                        </div>
+                    ))}
                 </div>
             </div>
         </Authenticated>

--- a/resources/js/types/notification/NotificationMessage.ts
+++ b/resources/js/types/notification/NotificationMessage.ts
@@ -2,4 +2,5 @@ export interface NotificationMessage {
     id: string;
     name: string;
     message: string;
+    data: string[];
 }

--- a/resources/views/mail/comment-made.blade.php
+++ b/resources/views/mail/comment-made.blade.php
@@ -1,9 +1,7 @@
 <x-mail::message>
 # Comment Created
 
-## {{ $commenter }} has commented the following on incident #{{$incidentSlug}}:
-
-{{ $content }}
+{{$message}}
 
 <x-mail::button :url="$url">
 View Incident

--- a/resources/views/mail/incident-additional-information.blade.php
+++ b/resources/views/mail/incident-additional-information.blade.php
@@ -1,9 +1,7 @@
 <x-mail::message>
 # Incident Additional Information Added
 
-## Incident #{{$incidentSlug}} has had the following information added:
-
-{{$additionalInformation}}
+{{$message}}}
 
 <x-mail::button :url="$url">
     View Incident

--- a/resources/views/mail/incident-assigned.blade.php
+++ b/resources/views/mail/incident-assigned.blade.php
@@ -1,9 +1,7 @@
 <x-mail::message>
 # Incident Assigned
 
-{{$supervisorName}}, you have been assigned to review incident #{{$incidentSlug}} by {{$adminName}}.
-
-Please submit an investigation within 24 hours and root cause analysis within 72 hours by visiting the following link:
+{{$message}}
 
 <x-mail::button :url="$url">
 View Incident

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature;
 
+use App\Enum\NotificationMessageType;
 use App\Models\Incident;
+use App\Models\NotificationMessage;
 use App\Models\User;
 use App\States\IncidentStatus\Assigned;
 use App\States\IncidentStatus\Closed;
@@ -12,6 +14,41 @@ use Tests\TestCase;
 
 class DashboardTest extends TestCase
 {
+    public function test_updating_notification_message()
+    {
+        $admin = User::factory()->create()->syncRoles('admin');
+        $this->actingAs($admin);
+
+        $notificationMessage = NotificationMessage::firstWhere('name', NotificationMessageType::INCIDENT_RECEIVED);
+
+        $response = $this->put(route('notifications.update-message', ['notification_message' => $notificationMessage->id]), [
+            'message' => 'some message'
+        ]);
+
+        $response->assertRedirect();
+
+        $notificationMessage->refresh();
+
+        $this->assertEquals('some message', $notificationMessage->message);
+    }
+
+    public function test_settings_page_returns_all_notification_messages()
+    {
+        $admin = User::factory()->create()->syncRoles('admin');
+        $this->actingAs($admin);
+
+        $response = $this->get(route('dashboard.settings'));
+
+
+        $response->assertStatus(200);
+
+        $response->assertInertia(function (AssertableInertia $page) {
+            $page->component('Dashboard/Settings')
+                ->has('notificationMessages', count(NotificationMessageType::cases()));
+        });
+
+    }
+
     public function test_admin_overview_returns_correct_days_open_average()
     {
         $admin = User::factory()->create()->syncRoles('admin');

--- a/tests/Feature/Incident/FileTest.php
+++ b/tests/Feature/Incident/FileTest.php
@@ -157,14 +157,14 @@ class FileTest extends TestCase
             UploadedFile::fake()->image('file.jpg')->size(100),
         ];
 
-        $response = $this->post(route('incidents.upload-files', $incident), ['files' => $files]);
+        $this->post(route('incidents.upload-files', $incident), ['files' => $files]);
 
         Notification::assertCount(3);
 
         Notification::assertSentTo(
             $admins,
             function (FilesUploadedNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentSlug === $incident->slug && $notification->user->id === $supervisor->id;
+                return $notification->data['incidentSlug'] === $incident->slug && $notification->data['name'] === $supervisor->name;
             }
         );
     }

--- a/tests/Feature/Incident/StatusTest.php
+++ b/tests/Feature/Incident/StatusTest.php
@@ -105,7 +105,7 @@ class StatusTest extends TestCase
         Notification::assertSentTo(
             $supervisor,
             function (InvestigationReturnedNotification $notification, array $channels) use ($incident, $admin) {
-                return $notification->incidentSlug === $incident->slug && $notification->admin->id === $admin->id;
+                return $notification->data['incidentSlug'] === $incident->slug && $notification->data['name'] === $admin->name;
             }
         );
     }
@@ -433,7 +433,7 @@ class StatusTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentSlug === $incident->slug && $notification->supervisor->id === $supervisor->id;
+                return $notification->data['incidentSlug'] === $incident->slug && $notification->data['name'] === $supervisor->name;
             }
         );
     }

--- a/tests/Feature/Incident/SupervisorTest.php
+++ b/tests/Feature/Incident/SupervisorTest.php
@@ -81,9 +81,8 @@ class SupervisorTest extends TestCase
             $supervisor,
             function (SupervisorAssignedNotification $notification, array $channels) use ($incident, $supervisor, $admin) {
                 return (
-                    $notification->incidentSlug === $incident->slug &&
-                    $notification->admin->id === $admin->id &&
-                    $notification->supervisor->id == $supervisor->id
+                    $notification->data['incidentSlug'] === $incident->slug &&
+                    $notification->data['name'] === $admin->name
                 );
             }
         );

--- a/tests/Feature/Investigation/StoreTest.php
+++ b/tests/Feature/Investigation/StoreTest.php
@@ -54,7 +54,7 @@ class StoreTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (InvestigationSubmittedNotification $notification, array $channels) use ($investigation, $supervisor) {
-                return $notification->investigationId === $investigation->id && $notification->supervisor->id === $supervisor->id;
+                return $notification->data['investigationId'] === $investigation->id && $notification->data['name'] === $supervisor->name;
             }
         );
     }

--- a/tests/Feature/RootCauseAnalysis/StoreTest.php
+++ b/tests/Feature/RootCauseAnalysis/StoreTest.php
@@ -77,7 +77,7 @@ class StoreTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (RootCauseAnalysisSubmittedNotification $notification, array $channels) use ($rca, $supervisor) {
-                return $notification->rootCauseAnalysisId === $rca->id && $notification->supervisor->id === $supervisor->id;
+                return $notification->data['rootCauseAnalysisId'] === $rca->id && $notification->data['name'] === $supervisor->name;
             }
         );
     }

--- a/tests/Unit/Aggregates/IncidentAggregateRootTest.php
+++ b/tests/Unit/Aggregates/IncidentAggregateRootTest.php
@@ -347,7 +347,7 @@ class IncidentAggregateRootTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentSlug === $incident->slug && $notification->supervisor->id === $supervisor->id;
+                return $notification->data['incidentSlug'] === $incident->slug && $notification->data['name'] === $supervisor->name;
             }
         );
     }

--- a/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
+++ b/tests/Unit/Aggregates/InvestigationAggregateRootTest.php
@@ -62,7 +62,7 @@ class InvestigationAggregateRootTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (InvestigationSubmittedNotification $notification, array $channels) use ($investigation, $supervisor) {
-                return $notification->investigationId === $investigation->id && $notification->supervisor->id === $supervisor->id;
+                return $notification->data['investigationId'] === $investigation->id && $notification->data['name'] === $supervisor->name;
             }
         );
     }

--- a/tests/Unit/Aggregates/RootCauseAnalysisAggregateRootTest.php
+++ b/tests/Unit/Aggregates/RootCauseAnalysisAggregateRootTest.php
@@ -84,7 +84,7 @@ class RootCauseAnalysisAggregateRootTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (RootCauseAnalysisSubmittedNotification $notification, array $channels) use ($rca, $supervisor) {
-                return $notification->rootCauseAnalysisId === $rca->id && $notification->supervisor->id === $supervisor->id;
+                return $notification->data['rootCauseAnalysisId'] === $rca->id && $notification->data['name'] === $supervisor->name;
             }
         );
     }

--- a/tests/Unit/Notification/BaseNotificationTest.php
+++ b/tests/Unit/Notification/BaseNotificationTest.php
@@ -22,5 +22,6 @@ class BaseNotificationTest extends TestCase
         $notification->parseMessage($notificationMessage->name);
 
         $this->assertStringContainsString('Some Name', $notification->message);
+        $this->assertStringNotContainsString('{name}', $notification->message);
     }
 }

--- a/tests/Unit/Notification/BaseNotificationTest.php
+++ b/tests/Unit/Notification/BaseNotificationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Unit\Notification;
+
+use App\Enum\NotificationMessageType;
+use App\Models\NotificationMessage;
+use App\Notifications\BaseNotification;
+use Tests\TestCase;
+
+class TestNotification extends BaseNotification
+{
+}
+
+class BaseNotificationTest extends TestCase
+{
+    public function test_notification_parse_message_injects_values_into_message()
+    {
+        $notification = new TestNotification;
+        $notification->data = ['name' => 'Some Name'];
+
+        $notificationMessage = NotificationMessage::firstWhere('name', NotificationMessageType::INCIDENT_ASSIGNED);
+        $notification->parseMessage($notificationMessage->name);
+
+        $this->assertStringContainsString('Some Name', $notification->message);
+    }
+}

--- a/tests/Unit/StoreableEvents/Incident/FilesUploadedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/FilesUploadedTest.php
@@ -35,7 +35,7 @@ class FilesUploadedTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (FilesUploadedNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentSlug === $incident->slug && $notification->user->id === $supervisor->id;
+                return $notification->data['incidentSlug'] === $incident->slug && $notification->data['name'] === $supervisor->name;
             }
         );
     }

--- a/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
+++ b/tests/Unit/StoreableEvents/Incident/IncidentReviewRequestedTest.php
@@ -79,7 +79,7 @@ class IncidentReviewRequestedTest extends TestCase
         Notification::assertSentTo(
             $admins,
             function (IncidentReviewRequestNotification $notification, array $channels) use ($incident, $supervisor) {
-                return $notification->incidentSlug === $incident->slug && $notification->supervisor->id === $supervisor->id;
+                return $notification->data['incidentSlug'] === $incident->slug && $notification->data['name'] === $supervisor->name;
             }
         );
     }

--- a/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
+++ b/tests/Unit/StoreableEvents/Investigation/InvestigationCreatedTest.php
@@ -150,9 +150,9 @@ class InvestigationCreatedTest extends TestCase
             $admins,
             function (InvestigationSubmittedNotification $notification, array $channels) use ($aggregateUuid, $supervisor, $incident) {
                 return (
-                    $notification->investigationId === $aggregateUuid
-                    && $notification->supervisor->id === $supervisor->id
-                    && $notification->incidentSlug === $incident->slug
+                    $notification->data['incidentSlug'] === $incident->slug &&
+                    $notification->data['investigationId'] === $aggregateUuid &&
+                    $notification->data['name'] === $supervisor->name
                 );
             }
         );

--- a/tests/Unit/StoreableEvents/RootCauseAnalysis/RootCauseAnalysisCreatedTest.php
+++ b/tests/Unit/StoreableEvents/RootCauseAnalysis/RootCauseAnalysisCreatedTest.php
@@ -83,9 +83,9 @@ class RootCauseAnalysisCreatedTest extends TestCase
             $admins,
             function (RootCauseAnalysisSubmittedNotification $notification, array $channels) use ($aggregateUuid, $supervisor, $incident) {
                 return (
-                    $notification->rootCauseAnalysisId === $aggregateUuid
-                    && $notification->supervisor->id === $supervisor->id
-                    && $notification->incidentSlug === $incident->slug
+                    $notification->data['incidentSlug'] === $incident->slug &&
+                    $notification->data['rootCauseAnalysisId'] === $aggregateUuid
+                    && $notification->data['name'] === $supervisor->name
                 );
             }
         );


### PR DESCRIPTION
# Feature Addition [CLOSES #341]

## Summary

Adds ability to edit all notification messages

## Rationale

Client request

## Design Documentation

NA

## Changes

- Updated NotificationMessageSeeder with entries for all notifications
- Updated NotificationMessageType enum with entries for all notifications
- Added migration for notification_message table which adds a data column of type jsonb. This column stores the variables that can be injected into a message as an array
- Updated all notifications to take in an associative array called $data. This array contains all of the variables in the notification message.  
- Added parseMessage method to BaseNotification which replace all variable place holders (ex. {name}) with the key of said placeholder from the $data associative array.
- Updated all mail templates to only display the notification message
- Updated Dashboard controller to pull all NotificationMessages
- Updated Settings page to render all NotificationMessages

## Impact

- Any new notifications should have a NotificationMessage entry in the database so it can be updated
- New notifications should also follow same implementation as the others

## Testing

- Broken tests updated
- Added unit test for parseMessage
- Added feature tests for dashboard.settings route

## Screenshots/Video

![image](https://github.com/user-attachments/assets/a2ac2a0d-3dfd-41fc-8dfc-df39437dfddf)


## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

NA
