### PR TITLE
Adds incident recording form for admins

### DIFF
--- a/app/Http/Controllers/Incident/IncidentAdminCreateController.php
+++ b/app/Http/Controllers/Incident/IncidentAdminCreateController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Incident;
+
+use App\Data\IncidentData;
+use App\Http\Controllers\Controller;
+use App\Models\Incident;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class IncidentAdminCreateController extends Controller
+{
+    public function __invoke(): Response
+    {
+        $this->authorize('viewAdminCreateForm', Incident::class);
+        return Inertia::render('Incident/AdminCreate', [
+            'incidentData' => IncidentData::empty(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Incident/IncidentController.php
+++ b/app/Http/Controllers/Incident/IncidentController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Incident;
 use App\Models\User;
 use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
@@ -56,13 +57,21 @@ class IncidentController extends Controller
     /**
      * Store a newly created Incident in storage.
      */
-    public function store(IncidentData $incidentData): Response
+    public function store(Request $request, IncidentData $incidentData): Response | RedirectResponse
     {
+        $validated = $request->validate([
+            'admin_submission' => 'boolean',
+        ]);
+
         $uuid = Str::uuid()->toString();
 
         IncidentAggregateRoot::retrieve(uuid: $uuid)
             ->createIncident($incidentData)
             ->persist();
+
+        if (isset($validated['admin_submission']) && $validated['admin_submission']) {
+            return redirect(route('incidents.show', ['incident' => $uuid]));
+        }
 
         return Inertia::render('Incident/Created', [
             'incident_id' => $uuid,

--- a/app/Policies/IncidentPolicy.php
+++ b/app/Policies/IncidentPolicy.php
@@ -108,4 +108,9 @@ class IncidentPolicy
         return $user->can('download any files') ||
             ($user->can('download own files') && $user->id == $file->user_id);
     }
+
+    public function viewAdminCreateForm(User $user): bool
+    {
+        return $user->can('perform admin actions');
+    }
 }

--- a/resources/js/Pages/Dashboard/AdminOverview.tsx
+++ b/resources/js/Pages/Dashboard/AdminOverview.tsx
@@ -102,7 +102,17 @@ export default function AdminOverview({ incidents, incidentCount, closedCount, u
 
                 {/* Latest Incidents Table */}
                 <div className="mt-8 rounded-lg bg-white p-6 shadow-lg">
-                    <h3 className="mb-2 ml-2 text-lg font-semibold text-gray-700">Latest Incidents</h3>
+                    <div className="mb-2 flex items-center justify-between">
+                        <h3 className="ml-2 text-lg font-semibold text-gray-700">Latest Incidents</h3>
+                        <Link
+                            as="button"
+                            className="bg-upei-green-500 hover:bg-upei-green-400 focus-visible:outline-upei-green-600 cursor-pointer rounded-md px-3 py-2 text-center text-sm font-semibold text-white shadow-xs focus-visible:outline focus-visible:outline-offset-2"
+                            href={route('incidents.create.admin')}
+                        >
+                            Record Incident
+                        </Link>
+                    </div>
+
                     <OverviewTable incidents={incidents} />
                 </div>
             </div>

--- a/resources/js/Pages/Incident/AdminCreate.tsx
+++ b/resources/js/Pages/Incident/AdminCreate.tsx
@@ -1,0 +1,266 @@
+import DangerButton from '@/Components/DangerButton';
+import DateInput from '@/Components/DateInput';
+import InputError from '@/Components/InputError';
+import InputLabel from '@/Components/InputLabel';
+import PrimaryButton from '@/Components/PrimaryButton';
+import PrimaryButtonDivider from '@/Components/PrimaryButtonDivider';
+import SelectInput from '@/Components/SelectInput';
+import TextArea from '@/Components/TextArea';
+import TextInput from '@/Components/TextInput';
+import ToggleSwitch from '@/Components/ToggleSwitch';
+import classNames from '@/Formatters/classNames';
+import dateFormat from '@/Formatters/dateFormat';
+import phoneNumberFormat from '@/Formatters/phoneNumberFormat';
+import Authenticated from '@/Layouts/AuthenticatedLayout';
+import { descriptors, locations, roles } from '@/Pages/Incident/Stages/IncidentDropDownValues';
+import IncidentData from '@/types/incident/IncidentData';
+import { PlusIcon } from '@heroicons/react/20/solid';
+import { Head, useForm } from '@inertiajs/react';
+import { FormEvent, useEffect } from 'react';
+
+export default function AdminCreate({ incidentData }: { incidentData: IncidentData }) {
+    const { data, setData, processing, errors, post } = useForm<Partial<IncidentData>>(incidentData);
+
+    const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        post(route('incidents.store', { admin_submission: true }));
+    };
+
+    useEffect(() => {
+        setData('role', roles[0].value);
+        setData('happened_at', dateFormat(new Date()));
+        setData('incident_type', descriptors[0].value);
+        setData('descriptor', descriptors[0].options[0]);
+        setData('anonymous', false);
+        setData('on_behalf', false);
+        setData('on_behalf_anonymous', false);
+        setData('work_related', false);
+        setData('has_injury', false);
+        setData('workers_comp_submitted', false);
+        setData('supervisor_name', '');
+    }, [setData]);
+
+    return (
+        <Authenticated>
+            <Head title={'Record Incident'} />
+            <form onSubmit={handleSubmit} className="mx-auto max-w-4xl space-y-4 rounded-md bg-white p-6 shadow-md">
+                <div className="text-center text-xl font-semibold text-gray-900">Record Incident</div>
+
+                <div className="space-y-2">
+                    <InputLabel>Anonymous</InputLabel>
+                    <ToggleSwitch onChange={(selected) => setData('anonymous', selected)} />
+                </div>
+                {!data['anonymous'] && (
+                    <div className="space-y-2">
+                        <InputLabel>Reporters Email</InputLabel>
+                        <TextInput value={data.reporters_email} onChange={(e) => setData('reporters_email', e.target.value)} />
+                    </div>
+                )}
+                <div className="space-y-2">
+                    <InputLabel>On Behalf</InputLabel>
+                    <ToggleSwitch onChange={(selected) => setData('on_behalf', selected)} />
+                </div>
+                {data.on_behalf && (
+                    <div className="space-y-2">
+                        <InputLabel>On Behalf Anonymous</InputLabel>
+                        <ToggleSwitch onChange={(selected) => setData('on_behalf_anonymous', selected)} />
+                    </div>
+                )}
+
+                {((!data.anonymous && !data.on_behalf) ||
+                    (!data.anonymous && data.on_behalf && !data.on_behalf_anonymous) ||
+                    (data.anonymous && data.on_behalf && !data.on_behalf_anonymous)) && (
+                    <>
+                        <div className="space-y-2">
+                            <InputLabel>First Name</InputLabel>
+                            <TextInput value={data.first_name} onChange={(e) => setData('first_name', e.target.value)} />
+                        </div>
+                        <div className="space-y-2">
+                            <InputLabel>Last Name</InputLabel>
+                            <TextInput value={data.last_name} onChange={(e) => setData('last_name', e.target.value)} />
+                        </div>
+                        <div className="space-y-2">
+                            <InputLabel>Phone Number</InputLabel>
+                            <TextInput value={data.phone} onChange={(e) => setData('phone', phoneNumberFormat(e.target.value))} />
+                        </div>
+                        <div className="space-y-2">
+                            <InputLabel>Email</InputLabel>
+                            <TextInput value={data.email} onChange={(e) => setData('email', e.target.value)} />
+                        </div>
+                        <div className="space-y-2">
+                            <InputLabel>Incident Role</InputLabel>
+                            <SelectInput
+                                value={roles.find(({ value }) => value === data?.role)?.name ?? roles[0].name}
+                                onChange={(e) => {
+                                    const role = roles.find(({ name }) => name === e.target.value);
+                                    setData('role', role?.value);
+                                    if (role?.name === 'Contractor' || role?.name === 'Visitor') {
+                                        setData('upei_id', '');
+                                    }
+                                }}
+                            >
+                                {roles.map(({ name }, i) => (
+                                    <option key={i}>{name}</option>
+                                ))}
+                            </SelectInput>
+                        </div>
+                        {(data.role === 1 || data.role === 2) && (
+                            <div className="space-y-2">
+                                <InputLabel>UPEI ID</InputLabel>
+                                <TextInput onChange={() => {}} />
+                            </div>
+                        )}
+                    </>
+                )}
+
+                <div className="space-y-2">
+                    <InputLabel>Happened On</InputLabel>
+                    <DateInput value={data.happened_at} onChange={(e) => setData('happened_at', e.target.value)} />
+                </div>
+                <div className="space-y-2">
+                    <InputLabel>Work Related</InputLabel>
+                    <ToggleSwitch onChange={(selected) => setData('work_related', selected)} />
+                </div>
+                <div className="space-y-2">
+                    <InputLabel>Location</InputLabel>
+                    <SelectInput value={data['location'] ?? ''} onChange={(e) => setData('location', e.target.value)}>
+                        {locations.map((option, index) => (
+                            <option key={index} value={option}>
+                                {option}
+                            </option>
+                        ))}
+                    </SelectInput>
+                </div>
+                <div className="space-y-2">
+                    <InputLabel>Room Number</InputLabel>
+                    <TextInput value={data.room_number} onChange={(e) => setData('room_number', e.target.value)} />
+                </div>
+                <div className="space-y-2">
+                    <InputLabel>Incident Type</InputLabel>
+                    <SelectInput
+                        value={descriptors.find(({ value }) => value === data?.incident_type)?.name ?? descriptors[0].name}
+                        onChange={(e) => {
+                            setData('incident_type', descriptors.find(({ name }) => name === e.target.value)?.value);
+                        }}
+                    >
+                        {descriptors.map(({ name }, index) => (
+                            <option key={index}>{name}</option>
+                        ))}
+                    </SelectInput>
+                </div>
+                <div>
+                    <InputLabel>Descriptor</InputLabel>
+                    <SelectInput value={data.descriptor} onChange={(e) => setData('descriptor', e.target.value)} className="w-full">
+                        {descriptors.map(
+                            ({ options, value }) =>
+                                value === data.incident_type && options.map((option, index) => <option key={index}>{option}</option>),
+                        )}
+                    </SelectInput>
+                </div>
+                <div className="space-y-2">
+                    <InputLabel>Has Injury</InputLabel>
+                    <ToggleSwitch onChange={(selected) => setData('has_injury', selected)} />
+                </div>
+                {data.has_injury && (
+                    <>
+                        <div className="space-y-2">
+                            <InputLabel>Injury Description</InputLabel>
+                            <TextArea value={data.injury_description} onChange={(e) => setData('injury_description', e.target.value)} />
+                        </div>
+                        {data.work_related && (
+                            <div className="space-y-2">
+                                <InputLabel>Workers Compensation Claim Submitted</InputLabel>
+                                <ToggleSwitch onChange={(selected) => setData('workers_comp_submitted', selected)} />
+                            </div>
+                        )}
+                    </>
+                )}
+
+                <div className="space-y-2">
+                    <InputLabel>Has First Aid</InputLabel>
+                    <ToggleSwitch onChange={(selected) => setData('first_aid_applied', selected)} />
+                </div>
+                {data.first_aid_applied && (
+                    <div className="space-y-2">
+                        <InputLabel>Injury Description</InputLabel>
+                        <TextArea value={data.first_aid_description} onChange={(e) => setData('first_aid_description', e.target.value)} />
+                    </div>
+                )}
+                <div className="space-y-2">
+                    <InputLabel>General Description</InputLabel>
+                    <TextArea value={data.description} onChange={(e) => setData('description', e.target.value)} />
+                </div>
+
+                <div className="flex w-full flex-col">
+                    {data.witnesses?.map(({ name, email, phone }, i) => (
+                        <div
+                            key={i}
+                            className={classNames(
+                                'flex flex-col gap-y-2 py-4',
+                                data.witnesses && i !== data.witnesses.length - 1 ? 'border-b border-gray-200' : '',
+                            )}
+                        >
+                            <div className="flex justify-between">
+                                <p>{`Witness #${i + 1}`}</p>
+                                <DangerButton
+                                    type="button"
+                                    onClick={() => setData('witnesses', [...(data.witnesses?.filter((_, index) => i !== index) ?? [])])}
+                                >
+                                    Delete
+                                </DangerButton>
+                            </div>
+                            <InputLabel>Name</InputLabel>
+                            <TextInput
+                                value={name}
+                                onChange={(e) => {
+                                    if (!data.witnesses) return;
+                                    data.witnesses[i].name = e.target.value;
+                                    setData('witnesses', data.witnesses);
+                                }}
+                            />
+                            <InputError message={errors[`witnesses.${i}.name` as keyof IncidentData]} className="mb-1" />
+                            <InputLabel>Email</InputLabel>
+                            <TextInput
+                                onChange={(e) => {
+                                    if (!data.witnesses) return;
+                                    data.witnesses[i].email = e.target.value;
+                                    setData('witnesses', data.witnesses);
+                                }}
+                                value={email}
+                            />
+                            <InputError message={errors[`witnesses.${i}.email` as keyof IncidentData]} className="mb-1" />
+                            <InputLabel>Phone</InputLabel>
+                            <TextInput
+                                onChange={(e) => {
+                                    if (!data.witnesses) return;
+                                    data.witnesses[i].phone = phoneNumberFormat(e.target.value);
+                                    setData('witnesses', data.witnesses);
+                                }}
+                                value={phone}
+                            />
+                            <InputError message={errors[`witnesses.${i}.phone` as keyof IncidentData]} className="mb-1" />
+                        </div>
+                    ))}
+                    <PrimaryButtonDivider
+                        type="button"
+                        className="self-end"
+                        onClick={() => setData('witnesses', [...(data.witnesses ?? []), { name: '', email: '', phone: '' }])}
+                    >
+                        <PlusIcon className="size-5" />
+                        Add Witness
+                    </PrimaryButtonDivider>
+                </div>
+
+                <div className="space-y-2">
+                    <InputLabel>Supervisor Name</InputLabel>
+                    <TextInput value={data.supervisor_name} onChange={(e) => setData('supervisor_name', e.target.value)} />
+                </div>
+                <div className="flex justify-center">
+                    <PrimaryButton disabled={processing} className="mt-6 w-20">
+                        Submit
+                    </PrimaryButton>
+                </div>
+            </form>
+        </Authenticated>
+    );
+}

--- a/resources/js/Pages/Incident/AdminCreate.tsx
+++ b/resources/js/Pages/Incident/AdminCreate.tsx
@@ -107,7 +107,7 @@ export default function AdminCreate({ incidentData }: { incidentData: IncidentDa
                         {(data.role === 1 || data.role === 2) && (
                             <div className="space-y-2">
                                 <InputLabel>UPEI ID</InputLabel>
-                                <TextInput onChange={() => {}} />
+                                <TextInput onChange={(e) => setData('upei_id', e.target.value)} />
                             </div>
                         )}
                     </>

--- a/resources/js/Pages/Incident/Stages/IncidentInformationStage.tsx
+++ b/resources/js/Pages/Incident/Stages/IncidentInformationStage.tsx
@@ -43,7 +43,7 @@ export default function IncidentInformationStage({ formData, setFormData }: Stag
                     <label className="block text-sm/6 font-medium text-gray-900">Location</label>
                 </div>
                 <div className="mt-1 grid grid-cols-1">
-                    <SelectInput value={formData.location || ''} onChange={(e) => setFormData('location', e.target.value)} className="w-full">
+                    <SelectInput value={formData.location ?? ''} onChange={(e) => setFormData('location', e.target.value)} className="w-full">
                         {locations.map((option, index) => (
                             <option key={index} value={option}>
                                 {option}

--- a/routes/incidents.php
+++ b/routes/incidents.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Incident\AssignedIncidentsController;
 use App\Http\Controllers\Incident\IncidentAdditionalInformationController;
+use App\Http\Controllers\Incident\IncidentAdminCreateController;
 use App\Http\Controllers\Incident\IncidentCommentController;
 use App\Http\Controllers\Incident\IncidentController;
 use App\Http\Controllers\Incident\IncidentFileController;
@@ -55,4 +56,5 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::post('/incidents/{incident}/comments', IncidentCommentController::class)->name('incidents.comments.store');
 
+    Route::get('/incidents/create/admin', IncidentAdminCreateController::class)->name('incidents.create.admin');
 });

--- a/tests/Feature/Incident/CreateTest.php
+++ b/tests/Feature/Incident/CreateTest.php
@@ -3,11 +3,42 @@
 namespace Tests\Feature\Incident;
 
 use App\Data\IncidentData;
+use App\Models\User;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
 class CreateTest extends TestCase
 {
+    public function test_admin_can_view_admin_create_form()
+    {
+        $admin = User::factory()->create()->syncRoles('admin');
+        $this->actingAs($admin);
+
+        $response = $this->get(route('incidents.create.admin'));
+
+        $response->assertOk();
+    }
+
+    public function test_supervisor_cant_view_admin_create_form()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $this->actingAs($supervisor);
+
+        $response = $this->get(route('incidents.create.admin'));
+
+        $response->assertForbidden();
+    }
+
+    public function test_user_cant_view_admin_create_form()
+    {
+        $user = User::factory()->create()->syncRoles('user');
+        $this->actingAs($user);
+
+        $response = $this->get(route('incidents.create.admin'));
+
+        $response->assertForbidden();
+    }
+
     public function test_shows_create_page_and_has_empty_form(): void
     {
         $response = $this->get(route('incidents.create'));

--- a/tests/Feature/Incident/StoreTest.php
+++ b/tests/Feature/Incident/StoreTest.php
@@ -20,6 +20,45 @@ use Tests\TestCase;
 
 class StoreTest extends TestCase
 {
+    public function test_admin_submission_redirects_to_show_page(): void
+    {
+        $incidentData = IncidentData::from([
+            'anonymous' => false,
+            'on_behalf' => false,
+            'on_behalf_anonymous' => false,
+            'role' => IncidentRoles::EMPLOYEE,
+            'last_name' => 'last',
+            'first_name' => 'first',
+            'upei_id' => '322',
+            'email' => 'john@doe.com',
+            'phone' => '(902) 333-4444',
+            'work_related' => true,
+            'workers_comp_submitted' => true,
+            'happened_at' => now(),
+            'location' => 'Building A',
+            'room_number' => '123A',
+            'witnesses' => [],
+            'incident_type' => IncidentType::SAFETY,
+            'descriptor' => 'Burn',
+            'description' => 'A fire broke out in the room.',
+            'injury_description' => 'Minor burn',
+            'first_aid_description' => 'Minor burn treated',
+            'reporters_email' => 'jane@doe.com',
+            'supervisor_name' => 'John Doe',
+        ]);
+
+        $this->assertDatabaseCount('incidents', 0);
+
+        $response = $this->post(route('incidents.store', ['admin_submission' => true]), $incidentData->toArray());
+
+        $this->assertDatabaseCount('incidents', 1);
+
+
+        $incident = Incident::first();
+
+        $response->assertRedirect(route('incidents.show', ['incident' => $incident->id]));
+    }
+
     public function test_user_id_on_event_if_not_anonymous()
     {
         $user = User::factory()->create();

--- a/tests/Unit/Policies/IncidentPolicyTest.php
+++ b/tests/Unit/Policies/IncidentPolicyTest.php
@@ -18,6 +18,27 @@ use Tests\TestCase;
 
 class IncidentPolicyTest extends TestCase
 {
+    public function test_user_cant_view_admin_create_form()
+    {
+        $user = User::factory()->create()->syncRoles('user');
+
+        $this->assertFalse($this->getPolicy()->viewAdminCreateForm($user));
+    }
+
+    public function test_supervisor_cant_view_admin_create_form()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+
+        $this->assertFalse($this->getPolicy()->viewAdminCreateForm($supervisor));
+    }
+
+    public function test_admin_can_view_admin_create_form()
+    {
+        $admin = User::factory()->create()->syncRoles('admin');
+
+        $this->assertTrue($this->getPolicy()->viewAdminCreateForm($admin));
+    }
+
     public function test_user_cant_download_files()
     {
         $user = User::factory()->create()->syncRoles('user');


### PR DESCRIPTION
# Feature Addition [CLOSES #343]

## Summary

Adds incident recording form for admins

## Rationale

Client request

## Design Documentation

NA

## Changes

- Adds Incident Admin Create page
- Adds route and policy for Admin Create page
- Adds button to access Admin Create page on Admin Overview page
- Adds an optional admin_submission query param to incident store method. Redirects user to show page if this is true

## Impact

NA

## Testing

- Updated incident policy test
- Updated incident create test

## Screenshots/Video

![image](https://github.com/user-attachments/assets/a4fa0ca0-953f-434b-afa3-28afe738ba9e)
![image](https://github.com/user-attachments/assets/c09e003b-26a7-44c7-a932-f8620fd2c577)


## Checklist

- [x] Code follows the project's coding standards

- [x] Unit tests covering the new feature have been added

- [x] All existing tests pass

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

NA
