### PR TITLE
Fixes notification message update loading indicator duplicating

### DIFF
--- a/resources/js/Pages/Dashboard/Settings.tsx
+++ b/resources/js/Pages/Dashboard/Settings.tsx
@@ -64,7 +64,7 @@ export default function Settings({ notificationMessages }: { notificationMessage
                             />
                             <InputError message={errors.message} />
 
-                            {processing ? (
+                            {processing && notificationBeingEdited?.id === notificationMessage.id ? (
                                 <LoadingIndicator />
                             ) : notificationBeingEdited?.id === notificationMessage.id ? (
                                 <div className="flex justify-between">


### PR DESCRIPTION
# Bug Fix

## Summary
Fixes notification message update loading indicator duplicating

## Issue Link

Fixes #349 

## Root Cause Analysis

Not checking current message being updated on conditional render of loading indicator.

## Changes

Added check for current message being updated on conditional render of loading indicator.

## Impact

NA

## Testing Strategy

Update a notification message

## Regression Risk

NA

## Checklist

- [x] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes

Any further information needed to understand the fix or its impact.
