### PR TITLE
351 user delete cascade changes

### DIFF
--- a/app/Models/Investigation.php
+++ b/app/Models/Investigation.php
@@ -33,6 +33,6 @@ class Investigation extends Model
 
     public function supervisor(): BelongsTo
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class)->withTrashed();
     }
 }

--- a/app/Models/RootCauseAnalysis.php
+++ b/app/Models/RootCauseAnalysis.php
@@ -43,6 +43,6 @@ class RootCauseAnalysis extends Model
 
     public function supervisor(): BelongsTo
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class)->withTrashed();
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -68,6 +69,11 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function incidents(): HasMany
+    {
+        return $this->hasMany(Incident::class, 'supervisor_id', 'id');
     }
 
     /**

--- a/app/StorableEvents/User/UserDeleted.php
+++ b/app/StorableEvents/User/UserDeleted.php
@@ -27,6 +27,8 @@ class UserDeleted extends StoredEvent
             }
         });
 
+        // Since we are using soft deletes supervisor and admins should be set to user
+        // in the event they sign in via oauth they will be restored but only as a user.
         $user->syncRoles('user');
 
         $user->delete();

--- a/app/StorableEvents/User/UserDeleted.php
+++ b/app/StorableEvents/User/UserDeleted.php
@@ -2,7 +2,10 @@
 
 namespace App\StorableEvents\User;
 
+use App\Models\Incident;
 use App\Models\User;
+use App\States\IncidentStatus\Assigned;
+use App\States\IncidentStatus\Opened;
 use App\StorableEvents\StoredEvent;
 
 class UserDeleted extends StoredEvent
@@ -15,6 +18,16 @@ class UserDeleted extends StoredEvent
     public function handle(): void
     {
         $user = User::find($this->user_id);
+
+        $user->incidents->each(function (Incident $incident) {
+            if ($incident->status::class == Assigned::class) {
+                $incident->supervisor_id = null;
+                $incident->status->transitionTo(Opened::class);
+                $incident->save();
+            }
+        });
+
+        $user->syncRoles('user');
 
         $user->delete();
     }

--- a/resources/js/Pages/Incident/Partials/ShowComponents/IncidentAdminActions.tsx
+++ b/resources/js/Pages/Incident/Partials/ShowComponents/IncidentAdminActions.tsx
@@ -19,7 +19,8 @@ export default function IncidentAdminActions({ incident, supervisors, roles }: A
                         {(incident.status === IncidentStatus.OPENED ||
                             incident.status === IncidentStatus.ASSIGNED ||
                             incident.status === IncidentStatus.REOPENED ||
-                            incident.status === IncidentStatus.IN_REVIEW) && (
+                            incident.status === IncidentStatus.IN_REVIEW ||
+                            incident.status === IncidentStatus.RETURNED) && (
                             <SupervisorUpdate incident={incident} supervisors={supervisors} roles={roles} />
                         )}
                         <StatusUpdate incident={incident} />

--- a/tests/Unit/Models/InvestigationTest.php
+++ b/tests/Unit/Models/InvestigationTest.php
@@ -9,6 +9,18 @@ use Tests\TestCase;
 
 class InvestigationTest extends TestCase
 {
+    public function test_investigation_belongs_to_trashed_supervisor_relation()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $investigation = Investigation::factory()->create(['supervisor_id' => $supervisor->id]);
+
+        $supervisor->delete();
+
+        $investigation->refresh();
+
+        $this->assertEquals($supervisor->id, $investigation->supervisor->id);
+    }
+
     public function test_investigation_belongs_to_supervisor_relation()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');

--- a/tests/Unit/Models/RootCauseAnalysisTest.php
+++ b/tests/Unit/Models/RootCauseAnalysisTest.php
@@ -9,6 +9,18 @@ use Tests\TestCase;
 
 class RootCauseAnalysisTest extends TestCase
 {
+    public function test_rca_belongs_to_trashed_supervisor_relation()
+    {
+        $supervisor = User::factory()->create()->syncRoles('supervisor');
+        $rca = RootCauseAnalysis::factory()->create(['supervisor_id' => $supervisor->id]);
+
+        $supervisor->delete();
+
+        $rca->refresh();
+
+        $this->assertEquals($supervisor->id, $rca->supervisor->id);
+    }
+
     public function test_rca_belongs_to_supervisor_relation()
     {
         $supervisor = User::factory()->create()->syncRoles('supervisor');

--- a/tests/Unit/StoreableEvents/User/UserDeletedTest.php
+++ b/tests/Unit/StoreableEvents/User/UserDeletedTest.php
@@ -2,12 +2,58 @@
 
 namespace Tests\Unit\StoreableEvents\User;
 
+use App\Models\Incident;
 use App\Models\User;
+use App\States\IncidentStatus\Assigned;
+use App\States\IncidentStatus\Opened;
 use App\StorableEvents\User\UserDeleted;
 use Tests\TestCase;
 
 class UserDeletedTest extends TestCase
 {
+    public function test_updates_assigned_status_to_open()
+    {
+        $user = User::factory()->create();
+
+        $incident = Incident::factory()->create(['status' => Assigned::class, 'supervisor_id' => $user->id]);
+
+        $event = new UserDeleted($user->id);
+
+        $event->handle();
+
+        $incident->refresh();
+
+        $this->assertEquals(Opened::class, $incident->status::class);
+    }
+
+    public function test_unassigns_user_from_assigned_incidents()
+    {
+        $user = User::factory()->create();
+
+        $incident = Incident::factory()->create(['status' => Assigned::class, 'supervisor_id' => $user->id]);
+
+        $event = new UserDeleted($user->id);
+
+        $event->handle();
+
+        $incident->refresh();
+
+        $this->assertNull($incident->supervisor_id);
+    }
+
+    public function test_gives_trashed_user_the_user_role()
+    {
+        $user = User::factory()->create();
+
+        $event = new UserDeleted($user->id);
+
+        $event->handle();
+
+        $user->refresh();
+
+        $this->assertTrue($user->hasExactRoles('user'));
+    }
+
     public function test_deletes_user()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
# Bug Fix

## Summary

Updates the logic related to deleted users.

## Issue Link

FIXES #351 

## Root Cause Analysis

If an assigned user was deleted it that incident would remain in the assigned status.

## Changes

- The supervisor relation on an investigation or RCA will now search through trashed users as well.
- When a user is deleted all incidents assigned to them will be moved to opened state
- When a user is deleted the trashed user will be assigned the user role.

## Impact

N/A

## Testing Strategy

Additional unit tests have been added.

## Regression Risk

N/A

## Checklist

- [ ] The fix has been locally tested

- [ ] New unit tests have been added to prevent future regressions

- [ ] The documentation has been updated if necessary

## Additional Notes

N/A